### PR TITLE
Add usage examples to README and Zygote.jl AD support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,47 @@ Target:
 | `permutedims` | `permutedims` | Dimension permutation |
 | `contract` | `contract` | Tensor contraction |
 
+## Usage
+
+### Rust
+
+```rust
+use ndtensors::{Tensor, contract};
+
+// Create tensors
+let a = Tensor::<f64>::from_vec(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0], &[2, 3]).unwrap();
+let b = Tensor::<f64>::ones(&[3, 4]);
+
+// Permute dimensions (transpose)
+let a_t = a.permutedims(&[1, 0]).unwrap();
+assert_eq!(a_t.shape(), &[3, 2]);
+
+// Tensor contraction: C[i,k] = A[i,j] * B[j,k]
+// Negative labels indicate contracted indices
+let c = contract(&a, &[1, -1], &b, &[-1, 2]).unwrap();
+assert_eq!(c.shape(), &[2, 4]);
+```
+
+### Julia (via C API)
+
+```julia
+using NDTensorsRS
+
+# Create tensors
+a = TensorF64(2, 3)
+fill!(a, 1.0)
+b = TensorF64(3, 4)
+fill!(b, 1.0)
+
+# Tensor contraction with AD support
+c = contract(a, (1, -1), b, (-1, 2))
+
+# Reverse-mode AD via ChainRules.jl
+using Zygote
+loss(a, b) = sum(Array(contract(a, (1, -1), b, (-1, 2))))
+grad_a, grad_b = Zygote.gradient(loss, a, b)
+```
+
 ## Design Document
 
 See [docs/design.md](docs/design.md) for technical details.

--- a/crates/ndtensors/src/lib.rs
+++ b/crates/ndtensors/src/lib.rs
@@ -35,6 +35,25 @@
 //! let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
 //! let t2: DenseTensor<f64> = Tensor::from_vec(data, &[2, 3]).unwrap();
 //! ```
+//!
+//! # Permutation and Contraction
+//!
+//! ```
+//! use ndtensors::{Tensor, contract};
+//!
+//! // Create tensors
+//! let a = Tensor::<f64>::from_vec(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0], &[2, 3]).unwrap();
+//! let b = Tensor::<f64>::ones(&[3, 4]);
+//!
+//! // Permute dimensions (transpose)
+//! let a_t = a.permutedims(&[1, 0]).unwrap();
+//! assert_eq!(a_t.shape(), &[3, 2]);
+//!
+//! // Tensor contraction: C[i,k] = A[i,j] * B[j,k]
+//! // Negative labels indicate contracted indices
+//! let c = contract(&a, &[1, -1], &b, &[-1, 2]).unwrap();
+//! assert_eq!(c.shape(), &[2, 4]);
+//! ```
 
 pub mod backend;
 pub mod contract;

--- a/julia/NDTensorsRS/Project.toml
+++ b/julia/NDTensorsRS/Project.toml
@@ -1,12 +1,21 @@
 name = "NDTensorsRS"
 uuid = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-authors = ["The ndtensors-rs contributors"]
 version = "0.1.0"
+authors = ["The ndtensors-rs contributors"]
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
 ChainRulesCore = "1"
+Zygote = "0.6"
 julia = "1.9"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
+
+[targets]
+test = ["Test", "Zygote"]


### PR DESCRIPTION
## Summary
- Add Usage section to README with Rust and Julia examples for permutedims and contract operations
- Add doctests in lib.rs to verify example code works
- Add ChainRules `rrule` for `Array(TensorF64)` and `getindex(TensorF64, Int)` to enable Zygote.jl differentiation
- Add Zygote as test dependency with comprehensive AD tests (matrix multiplication and inner product gradients)

## Test plan
- [x] Rust doctests pass (10 tests)
- [x] Rust unit tests pass (52 tests)
- [x] Julia tests pass (113 tests including new Zygote AD tests)
- [x] `cargo fmt --all` and `cargo clippy` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)