### PR TITLE
Implement BlockSparse Phase 1: Core types (Issue #21)

### DIFF
--- a/crates/ndtensors/Cargo.toml
+++ b/crates/ndtensors/Cargo.toml
@@ -12,6 +12,7 @@ faer-traits.workspace = true
 thiserror.workspace = true
 rand.workspace = true
 rand_distr.workspace = true
+smallvec = "1.11"
 
 [dev-dependencies]
 approx.workspace = true

--- a/crates/ndtensors/src/storage/blocksparse/block.rs
+++ b/crates/ndtensors/src/storage/blocksparse/block.rs
@@ -1,0 +1,273 @@
+//! Block type for BlockSparse storage.
+//!
+//! A Block represents coordinates identifying a specific block in a block-sparse tensor.
+//! It mirrors NDTensors.jl's `Block{N}` type.
+
+use smallvec::SmallVec;
+use std::hash::{Hash, Hasher};
+
+/// A block coordinate with precomputed hash.
+///
+/// Uses `SmallVec<[usize; 8]>` for efficient storage:
+/// - Stack allocation for common cases (N <= 8)
+/// - Heap fallback for larger dimensions
+///
+/// # Example
+/// ```
+/// use ndtensors::storage::blocksparse::Block;
+///
+/// let block = Block::new(&[1, 2, 3]);
+/// assert_eq!(block.ndims(), 3);
+/// assert_eq!(block[0], 1);
+/// assert_eq!(block[1], 2);
+/// assert_eq!(block[2], 3);
+/// ```
+#[derive(Clone, Debug)]
+pub struct Block {
+    coords: SmallVec<[usize; 8]>,
+    hash: u64,
+}
+
+impl Block {
+    /// Create a new Block from coordinates.
+    pub fn new(coords: &[usize]) -> Self {
+        let coords: SmallVec<[usize; 8]> = coords.iter().copied().collect();
+        let hash = compute_hash(&coords);
+        Self { coords, hash }
+    }
+
+    /// Create a new Block by collecting coordinates from an iterator.
+    pub fn collect_from<I: IntoIterator<Item = usize>>(iter: I) -> Self {
+        let coords: SmallVec<[usize; 8]> = iter.into_iter().collect();
+        let hash = compute_hash(&coords);
+        Self { coords, hash }
+    }
+
+    /// Get the number of dimensions.
+    #[inline]
+    pub fn ndims(&self) -> usize {
+        self.coords.len()
+    }
+
+    /// Get the coordinates as a slice.
+    #[inline]
+    pub fn coords(&self) -> &[usize] {
+        &self.coords
+    }
+
+    /// Get the precomputed hash value.
+    #[inline]
+    pub fn precomputed_hash(&self) -> u64 {
+        self.hash
+    }
+
+    /// Create a permuted block with reordered coordinates.
+    pub fn permute(&self, perm: &[usize]) -> Self {
+        assert_eq!(
+            perm.len(),
+            self.ndims(),
+            "permutation length must match block dimensions"
+        );
+        let new_coords: SmallVec<[usize; 8]> = perm.iter().map(|&i| self.coords[i]).collect();
+        let hash = compute_hash(&new_coords);
+        Self {
+            coords: new_coords,
+            hash,
+        }
+    }
+
+    /// Create a new block with one coordinate changed.
+    pub fn set(&self, index: usize, value: usize) -> Self {
+        let mut new_coords = self.coords.clone();
+        new_coords[index] = value;
+        let hash = compute_hash(&new_coords);
+        Self {
+            coords: new_coords,
+            hash,
+        }
+    }
+}
+
+impl std::ops::Index<usize> for Block {
+    type Output = usize;
+
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.coords[index]
+    }
+}
+
+impl PartialEq for Block {
+    fn eq(&self, other: &Self) -> bool {
+        // Fast path: check hash first
+        if self.hash != other.hash {
+            return false;
+        }
+        self.coords == other.coords
+    }
+}
+
+impl Eq for Block {}
+
+impl Hash for Block {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // Use precomputed hash
+        state.write_u64(self.hash);
+    }
+}
+
+impl PartialOrd for Block {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Block {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        // Lexicographic ordering (like CartesianIndex comparison in Julia)
+        self.coords.cmp(&other.coords)
+    }
+}
+
+impl std::fmt::Display for Block {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Block(")?;
+        for (i, &c) in self.coords.iter().enumerate() {
+            if i > 0 {
+                write!(f, ", ")?;
+            }
+            write!(f, "{}", c)?;
+        }
+        write!(f, ")")
+    }
+}
+
+/// Compute hash for block coordinates.
+///
+/// Uses FNV-1a hash algorithm for fast hashing of integer sequences.
+fn compute_hash(coords: &[usize]) -> u64 {
+    // FNV-1a hash
+    const FNV_OFFSET: u64 = 0xcbf29ce484222325;
+    const FNV_PRIME: u64 = 0x100000001b3;
+
+    let mut hash = FNV_OFFSET;
+    for &coord in coords {
+        hash ^= coord as u64;
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    hash
+}
+
+impl<const N: usize> From<[usize; N]> for Block {
+    fn from(coords: [usize; N]) -> Self {
+        Self::new(&coords)
+    }
+}
+
+impl From<&[usize]> for Block {
+    fn from(coords: &[usize]) -> Self {
+        Self::new(coords)
+    }
+}
+
+impl From<Vec<usize>> for Block {
+    fn from(coords: Vec<usize>) -> Self {
+        Self::new(&coords)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_block_creation() {
+        let block = Block::new(&[1, 2, 3]);
+        assert_eq!(block.ndims(), 3);
+        assert_eq!(block[0], 1);
+        assert_eq!(block[1], 2);
+        assert_eq!(block[2], 3);
+    }
+
+    #[test]
+    fn test_block_from_array() {
+        let block: Block = [1, 2, 3].into();
+        assert_eq!(block.ndims(), 3);
+        assert_eq!(block.coords(), &[1, 2, 3]);
+    }
+
+    #[test]
+    fn test_block_equality() {
+        let b1 = Block::new(&[1, 2, 3]);
+        let b2 = Block::new(&[1, 2, 3]);
+        let b3 = Block::new(&[1, 2, 4]);
+
+        assert_eq!(b1, b2);
+        assert_ne!(b1, b3);
+    }
+
+    #[test]
+    fn test_block_hash_consistency() {
+        let b1 = Block::new(&[1, 2, 3]);
+        let b2 = Block::new(&[1, 2, 3]);
+
+        assert_eq!(b1.precomputed_hash(), b2.precomputed_hash());
+
+        // Can be used as HashMap key
+        let mut map = HashMap::new();
+        map.insert(b1.clone(), 42);
+        assert_eq!(map.get(&b2), Some(&42));
+    }
+
+    #[test]
+    fn test_block_ordering() {
+        let b1 = Block::new(&[1, 2]);
+        let b2 = Block::new(&[1, 3]);
+        let b3 = Block::new(&[2, 1]);
+
+        assert!(b1 < b2);
+        assert!(b2 < b3);
+        assert!(b1 < b3);
+    }
+
+    #[test]
+    fn test_block_permute() {
+        let block = Block::new(&[10, 20, 30]);
+        let permuted = block.permute(&[2, 0, 1]);
+        assert_eq!(permuted.coords(), &[30, 10, 20]);
+    }
+
+    #[test]
+    fn test_block_set() {
+        let block = Block::new(&[1, 2, 3]);
+        let modified = block.set(1, 5);
+        assert_eq!(modified.coords(), &[1, 5, 3]);
+        // Original unchanged
+        assert_eq!(block.coords(), &[1, 2, 3]);
+    }
+
+    #[test]
+    fn test_block_display() {
+        let block = Block::new(&[1, 2, 3]);
+        assert_eq!(format!("{}", block), "Block(1, 2, 3)");
+    }
+
+    #[test]
+    fn test_empty_block() {
+        let block = Block::new(&[]);
+        assert_eq!(block.ndims(), 0);
+        assert_eq!(format!("{}", block), "Block()");
+    }
+
+    #[test]
+    fn test_large_block() {
+        // Test with more than 8 dimensions (heap allocation)
+        let coords: Vec<usize> = (0..12).collect();
+        let block = Block::new(&coords);
+        assert_eq!(block.ndims(), 12);
+        for i in 0..12 {
+            assert_eq!(block[i], i);
+        }
+    }
+}

--- a/crates/ndtensors/src/storage/blocksparse/block_dim.rs
+++ b/crates/ndtensors/src/storage/blocksparse/block_dim.rs
@@ -1,0 +1,468 @@
+//! BlockDim type for block sizes in each dimension.
+//!
+//! A BlockDim represents the block structure of one dimension of a block-sparse tensor.
+//! It mirrors NDTensors.jl's `BlockDim = Vector{Int}` type.
+
+/// Block dimension structure for a single axis.
+///
+/// Stores block sizes and precomputes cumulative offsets for fast lookup.
+///
+/// # Example
+/// ```
+/// use ndtensors::storage::blocksparse::BlockDim;
+///
+/// // Create a dimension with blocks of sizes [2, 3, 4]
+/// let dim = BlockDim::new(vec![2, 3, 4]);
+/// assert_eq!(dim.nblocks(), 3);
+/// assert_eq!(dim.total_size(), 9);  // 2 + 3 + 4
+/// assert_eq!(dim.block_size(0), 2);
+/// assert_eq!(dim.block_size(1), 3);
+/// assert_eq!(dim.block_size(2), 4);
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BlockDim {
+    /// Size of each block
+    block_sizes: Vec<usize>,
+    /// Cumulative offsets: cumulative[i] = sum of block_sizes[0..i]
+    cumulative: Vec<usize>,
+    /// Total size (sum of all block sizes)
+    total_size: usize,
+}
+
+impl BlockDim {
+    /// Create a new BlockDim from block sizes.
+    ///
+    /// # Arguments
+    /// * `block_sizes` - Vector of block sizes
+    ///
+    /// # Example
+    /// ```
+    /// use ndtensors::storage::blocksparse::BlockDim;
+    ///
+    /// let dim = BlockDim::new(vec![2, 3, 4]);
+    /// assert_eq!(dim.nblocks(), 3);
+    /// ```
+    pub fn new(block_sizes: Vec<usize>) -> Self {
+        let mut cumulative = Vec::with_capacity(block_sizes.len() + 1);
+        cumulative.push(0);
+
+        let mut total = 0usize;
+        for &size in &block_sizes {
+            total += size;
+            cumulative.push(total);
+        }
+
+        Self {
+            block_sizes,
+            cumulative,
+            total_size: total,
+        }
+    }
+
+    /// Create a BlockDim with uniform block sizes.
+    ///
+    /// # Arguments
+    /// * `nblocks` - Number of blocks
+    /// * `block_size` - Size of each block
+    ///
+    /// # Example
+    /// ```
+    /// use ndtensors::storage::blocksparse::BlockDim;
+    ///
+    /// let dim = BlockDim::uniform(3, 4);  // 3 blocks of size 4
+    /// assert_eq!(dim.nblocks(), 3);
+    /// assert_eq!(dim.total_size(), 12);
+    /// ```
+    pub fn uniform(nblocks: usize, block_size: usize) -> Self {
+        Self::new(vec![block_size; nblocks])
+    }
+
+    /// Get the number of blocks.
+    #[inline]
+    pub fn nblocks(&self) -> usize {
+        self.block_sizes.len()
+    }
+
+    /// Get the total size (sum of all block sizes).
+    #[inline]
+    pub fn total_size(&self) -> usize {
+        self.total_size
+    }
+
+    /// Get the size of a specific block.
+    ///
+    /// # Panics
+    /// Panics if block_index is out of bounds.
+    #[inline]
+    pub fn block_size(&self, block_index: usize) -> usize {
+        self.block_sizes[block_index]
+    }
+
+    /// Get the offset of a block (index where the block starts in dense storage).
+    ///
+    /// # Panics
+    /// Panics if block_index is out of bounds.
+    #[inline]
+    pub fn block_offset(&self, block_index: usize) -> usize {
+        self.cumulative[block_index]
+    }
+
+    /// Get all block sizes.
+    #[inline]
+    pub fn block_sizes(&self) -> &[usize] {
+        &self.block_sizes
+    }
+
+    /// Get cumulative offsets.
+    #[inline]
+    pub fn cumulative_offsets(&self) -> &[usize] {
+        &self.cumulative
+    }
+
+    /// Find which block contains a given index (in dense coordinates).
+    ///
+    /// Returns `(block_index, offset_within_block)`.
+    ///
+    /// # Panics
+    /// Panics if index is >= total_size.
+    ///
+    /// # Example
+    /// ```
+    /// use ndtensors::storage::blocksparse::BlockDim;
+    ///
+    /// let dim = BlockDim::new(vec![2, 3, 4]);
+    /// // Index 0, 1 are in block 0
+    /// assert_eq!(dim.find_block(0), (0, 0));
+    /// assert_eq!(dim.find_block(1), (0, 1));
+    /// // Index 2, 3, 4 are in block 1
+    /// assert_eq!(dim.find_block(2), (1, 0));
+    /// assert_eq!(dim.find_block(4), (1, 2));
+    /// // Index 5, 6, 7, 8 are in block 2
+    /// assert_eq!(dim.find_block(5), (2, 0));
+    /// ```
+    pub fn find_block(&self, index: usize) -> (usize, usize) {
+        assert!(
+            index < self.total_size,
+            "index {} out of bounds for BlockDim with total_size {}",
+            index,
+            self.total_size
+        );
+
+        // Binary search for the block
+        let block_index = match self.cumulative[1..].binary_search(&index) {
+            Ok(i) => i + 1, // Exactly at a boundary, belongs to next block
+            Err(i) => i,    // Falls within block i
+        };
+
+        let offset_within_block = index - self.cumulative[block_index];
+        (block_index, offset_within_block)
+    }
+
+    /// Check if block index is valid.
+    #[inline]
+    pub fn is_valid_block(&self, block_index: usize) -> bool {
+        block_index < self.nblocks()
+    }
+
+    /// Permute block sizes according to a permutation.
+    pub fn permute_blocks(&self, perm: &[usize]) -> Self {
+        assert_eq!(
+            perm.len(),
+            self.nblocks(),
+            "permutation length must match number of blocks"
+        );
+        let new_sizes: Vec<usize> = perm.iter().map(|&i| self.block_sizes[i]).collect();
+        Self::new(new_sizes)
+    }
+}
+
+impl std::fmt::Display for BlockDim {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "BlockDim({:?})", self.block_sizes)
+    }
+}
+
+impl From<Vec<usize>> for BlockDim {
+    fn from(block_sizes: Vec<usize>) -> Self {
+        Self::new(block_sizes)
+    }
+}
+
+impl<const N: usize> From<[usize; N]> for BlockDim {
+    fn from(block_sizes: [usize; N]) -> Self {
+        Self::new(block_sizes.to_vec())
+    }
+}
+
+/// Block dimensions for a multi-dimensional block-sparse tensor.
+///
+/// This is a collection of `BlockDim` for each dimension.
+///
+/// # Example
+/// ```
+/// use ndtensors::storage::blocksparse::{BlockDim, BlockDims};
+///
+/// let dims = BlockDims::new(vec![
+///     BlockDim::new(vec![2, 3]),    // Dimension 0: 2 blocks
+///     BlockDim::new(vec![4, 5, 6]), // Dimension 1: 3 blocks
+/// ]);
+/// assert_eq!(dims.ndims(), 2);
+/// assert_eq!(dims.nblocks().collect::<Vec<_>>(), vec![2, 3]);
+/// assert_eq!(dims.dense_shape(), vec![5, 15]);
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BlockDims {
+    dims: Vec<BlockDim>,
+}
+
+impl BlockDims {
+    /// Create BlockDims from a vector of BlockDim.
+    pub fn new(dims: Vec<BlockDim>) -> Self {
+        Self { dims }
+    }
+
+    /// Get the number of dimensions.
+    #[inline]
+    pub fn ndims(&self) -> usize {
+        self.dims.len()
+    }
+
+    /// Get the BlockDim for a specific dimension.
+    #[inline]
+    pub fn dim(&self, i: usize) -> &BlockDim {
+        &self.dims[i]
+    }
+
+    /// Get the number of blocks in each dimension.
+    pub fn nblocks(&self) -> impl Iterator<Item = usize> + '_ {
+        self.dims.iter().map(|d| d.nblocks())
+    }
+
+    /// Get the total number of possible blocks (product of nblocks in each dim).
+    pub fn total_nblocks(&self) -> usize {
+        self.dims.iter().map(|d| d.nblocks()).product()
+    }
+
+    /// Get the dense shape (total size in each dimension).
+    pub fn dense_shape(&self) -> Vec<usize> {
+        self.dims.iter().map(|d| d.total_size()).collect()
+    }
+
+    /// Get the total dense size (product of all dimensions).
+    pub fn dense_size(&self) -> usize {
+        self.dims.iter().map(|d| d.total_size()).product()
+    }
+
+    /// Get the size of a specific block.
+    ///
+    /// # Arguments
+    /// * `block_coords` - Block coordinates in each dimension
+    ///
+    /// # Returns
+    /// Total number of elements in the block.
+    pub fn block_size(&self, block_coords: &[usize]) -> usize {
+        assert_eq!(
+            block_coords.len(),
+            self.ndims(),
+            "block_coords length must match number of dimensions"
+        );
+        block_coords
+            .iter()
+            .zip(&self.dims)
+            .map(|(&coord, dim)| dim.block_size(coord))
+            .product()
+    }
+
+    /// Get the shape of a specific block.
+    pub fn block_shape(&self, block_coords: &[usize]) -> Vec<usize> {
+        assert_eq!(
+            block_coords.len(),
+            self.ndims(),
+            "block_coords length must match number of dimensions"
+        );
+        block_coords
+            .iter()
+            .zip(&self.dims)
+            .map(|(&coord, dim)| dim.block_size(coord))
+            .collect()
+    }
+
+    /// Check if block coordinates are valid.
+    pub fn is_valid_block(&self, block_coords: &[usize]) -> bool {
+        if block_coords.len() != self.ndims() {
+            return false;
+        }
+        block_coords
+            .iter()
+            .zip(&self.dims)
+            .all(|(&coord, dim)| dim.is_valid_block(coord))
+    }
+
+    /// Get all BlockDims.
+    #[inline]
+    pub fn as_slice(&self) -> &[BlockDim] {
+        &self.dims
+    }
+}
+
+impl std::ops::Index<usize> for BlockDims {
+    type Output = BlockDim;
+
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.dims[index]
+    }
+}
+
+impl IntoIterator for BlockDims {
+    type Item = BlockDim;
+    type IntoIter = std::vec::IntoIter<BlockDim>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.dims.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a BlockDims {
+    type Item = &'a BlockDim;
+    type IntoIter = std::slice::Iter<'a, BlockDim>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.dims.iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_block_dim_creation() {
+        let dim = BlockDim::new(vec![2, 3, 4]);
+        assert_eq!(dim.nblocks(), 3);
+        assert_eq!(dim.total_size(), 9);
+        assert_eq!(dim.block_sizes(), &[2, 3, 4]);
+    }
+
+    #[test]
+    fn test_block_dim_uniform() {
+        let dim = BlockDim::uniform(4, 5);
+        assert_eq!(dim.nblocks(), 4);
+        assert_eq!(dim.total_size(), 20);
+        assert_eq!(dim.block_sizes(), &[5, 5, 5, 5]);
+    }
+
+    #[test]
+    fn test_block_dim_offsets() {
+        let dim = BlockDim::new(vec![2, 3, 4]);
+        assert_eq!(dim.block_offset(0), 0);
+        assert_eq!(dim.block_offset(1), 2);
+        assert_eq!(dim.block_offset(2), 5);
+        assert_eq!(dim.cumulative_offsets(), &[0, 2, 5, 9]);
+    }
+
+    #[test]
+    fn test_block_dim_find_block() {
+        let dim = BlockDim::new(vec![2, 3, 4]);
+
+        // Block 0: indices 0, 1
+        assert_eq!(dim.find_block(0), (0, 0));
+        assert_eq!(dim.find_block(1), (0, 1));
+
+        // Block 1: indices 2, 3, 4
+        assert_eq!(dim.find_block(2), (1, 0));
+        assert_eq!(dim.find_block(3), (1, 1));
+        assert_eq!(dim.find_block(4), (1, 2));
+
+        // Block 2: indices 5, 6, 7, 8
+        assert_eq!(dim.find_block(5), (2, 0));
+        assert_eq!(dim.find_block(6), (2, 1));
+        assert_eq!(dim.find_block(7), (2, 2));
+        assert_eq!(dim.find_block(8), (2, 3));
+    }
+
+    #[test]
+    fn test_block_dim_permute() {
+        let dim = BlockDim::new(vec![2, 3, 4]);
+        let permuted = dim.permute_blocks(&[2, 0, 1]);
+        assert_eq!(permuted.block_sizes(), &[4, 2, 3]);
+    }
+
+    #[test]
+    fn test_block_dim_display() {
+        let dim = BlockDim::new(vec![2, 3, 4]);
+        assert_eq!(format!("{}", dim), "BlockDim([2, 3, 4])");
+    }
+
+    #[test]
+    fn test_block_dims_creation() {
+        let dims = BlockDims::new(vec![
+            BlockDim::new(vec![2, 3]),
+            BlockDim::new(vec![4, 5, 6]),
+        ]);
+        assert_eq!(dims.ndims(), 2);
+        assert_eq!(dims.nblocks().collect::<Vec<_>>(), vec![2, 3]);
+        assert_eq!(dims.total_nblocks(), 6);
+    }
+
+    #[test]
+    fn test_block_dims_dense_shape() {
+        let dims = BlockDims::new(vec![
+            BlockDim::new(vec![2, 3]),
+            BlockDim::new(vec![4, 5, 6]),
+        ]);
+        assert_eq!(dims.dense_shape(), vec![5, 15]);
+        assert_eq!(dims.dense_size(), 75);
+    }
+
+    #[test]
+    fn test_block_dims_block_size() {
+        let dims = BlockDims::new(vec![
+            BlockDim::new(vec![2, 3]),    // blocks of size 2, 3
+            BlockDim::new(vec![4, 5, 6]), // blocks of size 4, 5, 6
+        ]);
+
+        // Block (0, 0): 2 * 4 = 8
+        assert_eq!(dims.block_size(&[0, 0]), 8);
+        // Block (0, 1): 2 * 5 = 10
+        assert_eq!(dims.block_size(&[0, 1]), 10);
+        // Block (1, 2): 3 * 6 = 18
+        assert_eq!(dims.block_size(&[1, 2]), 18);
+    }
+
+    #[test]
+    fn test_block_dims_block_shape() {
+        let dims = BlockDims::new(vec![
+            BlockDim::new(vec![2, 3]),
+            BlockDim::new(vec![4, 5, 6]),
+        ]);
+
+        assert_eq!(dims.block_shape(&[0, 0]), vec![2, 4]);
+        assert_eq!(dims.block_shape(&[1, 2]), vec![3, 6]);
+    }
+
+    #[test]
+    fn test_block_dims_is_valid_block() {
+        let dims = BlockDims::new(vec![
+            BlockDim::new(vec![2, 3]),
+            BlockDim::new(vec![4, 5, 6]),
+        ]);
+
+        assert!(dims.is_valid_block(&[0, 0]));
+        assert!(dims.is_valid_block(&[1, 2]));
+        assert!(!dims.is_valid_block(&[2, 0])); // Out of bounds in dim 0
+        assert!(!dims.is_valid_block(&[0, 3])); // Out of bounds in dim 1
+        assert!(!dims.is_valid_block(&[0])); // Wrong number of dimensions
+    }
+
+    #[test]
+    fn test_block_dims_indexing() {
+        let dims = BlockDims::new(vec![
+            BlockDim::new(vec![2, 3]),
+            BlockDim::new(vec![4, 5, 6]),
+        ]);
+
+        assert_eq!(dims[0].block_sizes(), &[2, 3]);
+        assert_eq!(dims[1].block_sizes(), &[4, 5, 6]);
+    }
+}

--- a/crates/ndtensors/src/storage/blocksparse/block_offsets.rs
+++ b/crates/ndtensors/src/storage/blocksparse/block_offsets.rs
@@ -1,0 +1,381 @@
+//! BlockOffsets for mapping blocks to storage offsets.
+//!
+//! Provides O(1) lookup from block coordinates to data offsets in the flat storage.
+
+use std::collections::HashMap;
+
+use super::block::Block;
+use super::block_dim::BlockDims;
+
+/// Maps blocks to their offsets in flat storage.
+///
+/// Uses HashMap with Block's precomputed hash for O(1) lookup.
+///
+/// # Example
+/// ```
+/// use ndtensors::storage::blocksparse::{Block, BlockDim, BlockDims, BlockOffsets};
+///
+/// let dims = BlockDims::new(vec![
+///     BlockDim::new(vec![2, 3]),
+///     BlockDim::new(vec![4, 5]),
+/// ]);
+///
+/// // Create offsets for blocks (0,0), (0,1), (1,1)
+/// let blocks = vec![
+///     Block::new(&[0, 0]),
+///     Block::new(&[0, 1]),
+///     Block::new(&[1, 1]),
+/// ];
+/// let offsets = BlockOffsets::from_blocks(&blocks, &dims);
+///
+/// assert_eq!(offsets.nnzblocks(), 3);
+/// assert_eq!(offsets.get(&Block::new(&[0, 0])), Some(0));
+/// ```
+#[derive(Clone, Debug)]
+pub struct BlockOffsets {
+    /// Map from Block to offset in flat storage
+    offsets: HashMap<Block, usize>,
+    /// Total number of non-zero elements
+    total_nnz: usize,
+}
+
+impl BlockOffsets {
+    /// Create an empty BlockOffsets.
+    pub fn new() -> Self {
+        Self {
+            offsets: HashMap::new(),
+            total_nnz: 0,
+        }
+    }
+
+    /// Create BlockOffsets from a list of blocks and block dimensions.
+    ///
+    /// Blocks are stored in the order given, with offsets computed sequentially.
+    ///
+    /// # Arguments
+    /// * `blocks` - List of blocks to include
+    /// * `dims` - Block dimensions for computing block sizes
+    ///
+    /// # Example
+    /// ```
+    /// use ndtensors::storage::blocksparse::{Block, BlockDim, BlockDims, BlockOffsets};
+    ///
+    /// let dims = BlockDims::new(vec![
+    ///     BlockDim::new(vec![2, 3]),
+    ///     BlockDim::new(vec![4, 5]),
+    /// ]);
+    /// let blocks = vec![Block::new(&[0, 0]), Block::new(&[1, 1])];
+    /// let offsets = BlockOffsets::from_blocks(&blocks, &dims);
+    ///
+    /// // Block (0,0) has size 2*4 = 8, starts at 0
+    /// assert_eq!(offsets.get(&Block::new(&[0, 0])), Some(0));
+    /// // Block (1,1) has size 3*5 = 15, starts at 8
+    /// assert_eq!(offsets.get(&Block::new(&[1, 1])), Some(8));
+    /// assert_eq!(offsets.total_nnz(), 23); // 8 + 15
+    /// ```
+    pub fn from_blocks(blocks: &[Block], dims: &BlockDims) -> Self {
+        let mut offsets = HashMap::with_capacity(blocks.len());
+        let mut current_offset = 0;
+
+        for block in blocks {
+            offsets.insert(block.clone(), current_offset);
+            let block_size = dims.block_size(block.coords());
+            current_offset += block_size;
+        }
+
+        Self {
+            offsets,
+            total_nnz: current_offset,
+        }
+    }
+
+    /// Create BlockOffsets with explicit offsets.
+    ///
+    /// # Arguments
+    /// * `block_offsets` - Iterator of (Block, offset) pairs
+    /// * `total_nnz` - Total number of non-zero elements
+    pub fn from_iter<I>(block_offsets: I, total_nnz: usize) -> Self
+    where
+        I: IntoIterator<Item = (Block, usize)>,
+    {
+        Self {
+            offsets: block_offsets.into_iter().collect(),
+            total_nnz,
+        }
+    }
+
+    /// Get the offset for a block.
+    ///
+    /// Returns `None` if the block is not present.
+    #[inline]
+    pub fn get(&self, block: &Block) -> Option<usize> {
+        self.offsets.get(block).copied()
+    }
+
+    /// Check if a block is present.
+    #[inline]
+    pub fn contains(&self, block: &Block) -> bool {
+        self.offsets.contains_key(block)
+    }
+
+    /// Get the number of non-zero blocks.
+    #[inline]
+    pub fn nnzblocks(&self) -> usize {
+        self.offsets.len()
+    }
+
+    /// Get the total number of non-zero elements.
+    #[inline]
+    pub fn total_nnz(&self) -> usize {
+        self.total_nnz
+    }
+
+    /// Check if there are no blocks.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.offsets.is_empty()
+    }
+
+    /// Iterate over all (block, offset) pairs.
+    pub fn iter(&self) -> impl Iterator<Item = (&Block, &usize)> {
+        self.offsets.iter()
+    }
+
+    /// Iterate over all blocks.
+    pub fn blocks(&self) -> impl Iterator<Item = &Block> {
+        self.offsets.keys()
+    }
+
+    /// Get all blocks as a sorted vector.
+    pub fn sorted_blocks(&self) -> Vec<Block> {
+        let mut blocks: Vec<_> = self.offsets.keys().cloned().collect();
+        blocks.sort();
+        blocks
+    }
+
+    /// Insert a block with its offset.
+    ///
+    /// Returns the previous offset if the block was already present.
+    pub fn insert(&mut self, block: Block, offset: usize) -> Option<usize> {
+        self.offsets.insert(block, offset)
+    }
+
+    /// Set the total nnz value.
+    pub fn set_total_nnz(&mut self, total_nnz: usize) {
+        self.total_nnz = total_nnz;
+    }
+
+    /// Get the size of a block given its position in storage.
+    ///
+    /// This requires knowing the offset of the next block or total_nnz.
+    pub fn block_size_at(&self, block: &Block, dims: &BlockDims) -> Option<usize> {
+        if self.contains(block) {
+            Some(dims.block_size(block.coords()))
+        } else {
+            None
+        }
+    }
+
+    /// Create a permuted version of BlockOffsets.
+    ///
+    /// # Arguments
+    /// * `perm` - Permutation to apply to block coordinates
+    /// * `dims` - Original block dimensions
+    ///
+    /// # Returns
+    /// New BlockOffsets with permuted blocks and recomputed offsets.
+    pub fn permute(&self, perm: &[usize], dims: &BlockDims) -> (Self, BlockDims) {
+        // Permute the dimensions
+        let new_dim_vec: Vec<_> = perm.iter().map(|&i| dims.dim(i).clone()).collect();
+        let new_dims = BlockDims::new(new_dim_vec);
+
+        // Permute each block and collect
+        let permuted_blocks: Vec<Block> = self.blocks().map(|b| b.permute(perm)).collect();
+
+        // Sort blocks and recompute offsets
+        let mut sorted_blocks = permuted_blocks;
+        sorted_blocks.sort();
+
+        let new_offsets = Self::from_blocks(&sorted_blocks, &new_dims);
+        (new_offsets, new_dims)
+    }
+}
+
+impl Default for BlockOffsets {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Display for BlockOffsets {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "BlockOffsets(nnzblocks={}, total_nnz={})",
+            self.nnzblocks(),
+            self.total_nnz
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::blocksparse::BlockDim;
+
+    fn create_test_dims() -> BlockDims {
+        BlockDims::new(vec![
+            BlockDim::new(vec![2, 3]), // blocks of size 2, 3
+            BlockDim::new(vec![4, 5]), // blocks of size 4, 5
+        ])
+    }
+
+    #[test]
+    fn test_block_offsets_empty() {
+        let offsets = BlockOffsets::new();
+        assert_eq!(offsets.nnzblocks(), 0);
+        assert_eq!(offsets.total_nnz(), 0);
+        assert!(offsets.is_empty());
+    }
+
+    #[test]
+    fn test_block_offsets_from_blocks() {
+        let dims = create_test_dims();
+        let blocks = vec![
+            Block::new(&[0, 0]), // size: 2 * 4 = 8
+            Block::new(&[0, 1]), // size: 2 * 5 = 10
+            Block::new(&[1, 0]), // size: 3 * 4 = 12
+        ];
+
+        let offsets = BlockOffsets::from_blocks(&blocks, &dims);
+
+        assert_eq!(offsets.nnzblocks(), 3);
+        assert_eq!(offsets.total_nnz(), 30); // 8 + 10 + 12
+
+        assert_eq!(offsets.get(&Block::new(&[0, 0])), Some(0));
+        assert_eq!(offsets.get(&Block::new(&[0, 1])), Some(8));
+        assert_eq!(offsets.get(&Block::new(&[1, 0])), Some(18));
+    }
+
+    #[test]
+    fn test_block_offsets_contains() {
+        let dims = create_test_dims();
+        let blocks = vec![Block::new(&[0, 0]), Block::new(&[1, 1])];
+
+        let offsets = BlockOffsets::from_blocks(&blocks, &dims);
+
+        assert!(offsets.contains(&Block::new(&[0, 0])));
+        assert!(offsets.contains(&Block::new(&[1, 1])));
+        assert!(!offsets.contains(&Block::new(&[0, 1])));
+        assert!(!offsets.contains(&Block::new(&[1, 0])));
+    }
+
+    #[test]
+    fn test_block_offsets_iteration() {
+        let dims = create_test_dims();
+        let blocks = vec![Block::new(&[0, 0]), Block::new(&[1, 1])];
+
+        let offsets = BlockOffsets::from_blocks(&blocks, &dims);
+
+        let collected: Vec<_> = offsets.blocks().collect();
+        assert_eq!(collected.len(), 2);
+    }
+
+    #[test]
+    fn test_block_offsets_sorted_blocks() {
+        let dims = create_test_dims();
+        // Insert in non-sorted order
+        let blocks = vec![
+            Block::new(&[1, 1]),
+            Block::new(&[0, 0]),
+            Block::new(&[1, 0]),
+        ];
+
+        let offsets = BlockOffsets::from_blocks(&blocks, &dims);
+        let sorted = offsets.sorted_blocks();
+
+        assert_eq!(sorted[0], Block::new(&[0, 0]));
+        assert_eq!(sorted[1], Block::new(&[1, 0]));
+        assert_eq!(sorted[2], Block::new(&[1, 1]));
+    }
+
+    #[test]
+    fn test_block_offsets_insert() {
+        let mut offsets = BlockOffsets::new();
+
+        assert!(offsets.insert(Block::new(&[0, 0]), 0).is_none());
+        assert!(offsets.insert(Block::new(&[1, 1]), 10).is_none());
+
+        // Inserting same block returns previous value
+        assert_eq!(offsets.insert(Block::new(&[0, 0]), 5), Some(0));
+
+        assert_eq!(offsets.get(&Block::new(&[0, 0])), Some(5));
+    }
+
+    #[test]
+    fn test_block_offsets_block_size_at() {
+        let dims = create_test_dims();
+        let blocks = vec![Block::new(&[0, 0]), Block::new(&[1, 1])];
+
+        let offsets = BlockOffsets::from_blocks(&blocks, &dims);
+
+        // Block (0, 0): 2 * 4 = 8
+        assert_eq!(offsets.block_size_at(&Block::new(&[0, 0]), &dims), Some(8));
+        // Block (1, 1): 3 * 5 = 15
+        assert_eq!(offsets.block_size_at(&Block::new(&[1, 1]), &dims), Some(15));
+        // Non-existent block
+        assert_eq!(offsets.block_size_at(&Block::new(&[0, 1]), &dims), None);
+    }
+
+    #[test]
+    fn test_block_offsets_display() {
+        let dims = create_test_dims();
+        let blocks = vec![Block::new(&[0, 0]), Block::new(&[1, 1])];
+
+        let offsets = BlockOffsets::from_blocks(&blocks, &dims);
+        let display = format!("{}", offsets);
+
+        assert!(display.contains("nnzblocks=2"));
+        assert!(display.contains("total_nnz=23")); // 8 + 15
+    }
+
+    #[test]
+    fn test_block_offsets_permute() {
+        let dims = BlockDims::new(vec![
+            BlockDim::new(vec![2, 3]), // dim 0
+            BlockDim::new(vec![4, 5]), // dim 1
+        ]);
+
+        let blocks = vec![
+            Block::new(&[0, 0]), // size: 2 * 4 = 8
+            Block::new(&[1, 1]), // size: 3 * 5 = 15
+        ];
+
+        let offsets = BlockOffsets::from_blocks(&blocks, &dims);
+
+        // Permute: swap dimensions
+        let (permuted_offsets, permuted_dims) = offsets.permute(&[1, 0], &dims);
+
+        // After permutation: (0, 0) -> (0, 0), (1, 1) -> (1, 1)
+        // Dimensions swapped: dim 0 is now [4, 5], dim 1 is now [2, 3]
+        assert_eq!(permuted_dims.dim(0).block_sizes(), &[4, 5]);
+        assert_eq!(permuted_dims.dim(1).block_sizes(), &[2, 3]);
+
+        // Block (0, 0) permuted is still (0, 0) with size 4 * 2 = 8
+        assert!(permuted_offsets.contains(&Block::new(&[0, 0])));
+        // Block (1, 1) permuted is still (1, 1) with size 5 * 3 = 15
+        assert!(permuted_offsets.contains(&Block::new(&[1, 1])));
+    }
+
+    #[test]
+    fn test_block_offsets_from_iter() {
+        let pairs = vec![(Block::new(&[0, 0]), 0), (Block::new(&[1, 1]), 8)];
+
+        let offsets = BlockOffsets::from_iter(pairs, 23);
+
+        assert_eq!(offsets.nnzblocks(), 2);
+        assert_eq!(offsets.total_nnz(), 23);
+        assert_eq!(offsets.get(&Block::new(&[0, 0])), Some(0));
+        assert_eq!(offsets.get(&Block::new(&[1, 1])), Some(8));
+    }
+}

--- a/crates/ndtensors/src/storage/blocksparse/mod.rs
+++ b/crates/ndtensors/src/storage/blocksparse/mod.rs
@@ -1,0 +1,47 @@
+//! BlockSparse storage types for sparse block tensors.
+//!
+//! This module provides the core types for block-sparse tensor storage,
+//! mirroring NDTensors.jl's BlockSparse implementation.
+//!
+//! # Overview
+//!
+//! Block-sparse tensors store only non-zero blocks, which is efficient
+//! for tensors with block-structured sparsity patterns (common in
+//! quantum physics and tensor network applications).
+//!
+//! ## Core Types
+//!
+//! - [`Block`] - Block coordinates with precomputed hash
+//! - [`BlockDim`] - Block sizes for a single dimension
+//! - [`BlockDims`] - Block dimensions for all tensor dimensions
+//! - [`BlockOffsets`] - Mapping from blocks to storage offsets
+//!
+//! # Example
+//!
+//! ```
+//! use ndtensors::storage::blocksparse::{Block, BlockDim, BlockDims, BlockOffsets};
+//!
+//! // Define block structure: 2 blocks in dim 0, 3 blocks in dim 1
+//! let dims = BlockDims::new(vec![
+//!     BlockDim::new(vec![2, 3]),    // dim 0: blocks of size 2, 3
+//!     BlockDim::new(vec![4, 5, 6]), // dim 1: blocks of size 4, 5, 6
+//! ]);
+//!
+//! // Only store blocks (0,0), (0,2), (1,1)
+//! let blocks = vec![
+//!     Block::new(&[0, 0]),
+//!     Block::new(&[0, 2]),
+//!     Block::new(&[1, 1]),
+//! ];
+//!
+//! let offsets = BlockOffsets::from_blocks(&blocks, &dims);
+//! println!("Total non-zeros: {}", offsets.total_nnz());
+//! ```
+
+mod block;
+mod block_dim;
+mod block_offsets;
+
+pub use block::Block;
+pub use block_dim::{BlockDim, BlockDims};
+pub use block_offsets::BlockOffsets;

--- a/crates/ndtensors/src/storage/mod.rs
+++ b/crates/ndtensors/src/storage/mod.rs
@@ -6,7 +6,7 @@
 //! TensorStorage<ElT> (trait)
 //! ├── Dense<ElT, D>    - Contiguous array storage (generic over DataBuffer)
 //! ├── Diag<ElT>        - Diagonal storage (future)
-//! └── BlockSparse<ElT> - Block sparse storage (future)
+//! └── BlockSparse<ElT> - Block sparse storage
 //! ```
 //!
 //! ## Backend Abstraction
@@ -20,6 +20,7 @@
 //! └── MetalBuffer<T> - Apple Metal backend (future)
 //! ```
 
+pub mod blocksparse;
 pub mod buffer;
 mod dense;
 


### PR DESCRIPTION
## Summary

Implement core types for BlockSparse storage, mirroring NDTensors.jl's blocksparse implementation.

### Added Types

- **Block**: Block coordinates with precomputed hash using `SmallVec<[usize; 8]>`
- **BlockDim**: Block sizes for a single dimension with cumulative offsets
- **BlockDims**: Collection of BlockDim for multi-dimensional tensors
- **BlockOffsets**: HashMap-based block to offset mapping with O(1) lookup

### Features

- Efficient stack allocation for common cases (N <= 8 dimensions)
- FNV-1a hash for fast block coordinate hashing
- Comprehensive unit tests (32 tests) and documentation

### Files

- `crates/ndtensors/src/storage/blocksparse/block.rs`
- `crates/ndtensors/src/storage/blocksparse/block_dim.rs`
- `crates/ndtensors/src/storage/blocksparse/block_offsets.rs`
- `crates/ndtensors/src/storage/blocksparse/mod.rs`

## Test plan

- [x] All unit tests pass (32 blocksparse tests)
- [x] All doctests pass (9 blocksparse doctests)
- [x] cargo clippy passes
- [x] cargo fmt applied

Closes #21

🤖 Generated with [Claude Code](https://claude.ai/claude-code)