### PR TITLE
Add linear algebra utilities: random_orthog, random_unitary, QL decomposition, and positive factorization

### DIFF
--- a/crates/ndtensors/src/decomposition/mod.rs
+++ b/crates/ndtensors/src/decomposition/mod.rs
@@ -7,7 +7,8 @@
 //! # Available Decompositions
 //!
 //! - [`svd`] / [`svd_truncated`]: Singular Value Decomposition
-//! - [`qr`]: QR Decomposition
+//! - [`qr`] / [`qr_positive`]: QR Decomposition (with optional positive diagonal)
+//! - [`ql`] / [`ql_positive`]: QL Decomposition (with optional positive diagonal)
 //! - [`polar`]: Polar Decomposition (A = U * P)
 //! - [`matrix_exp`]: Matrix Exponential
 //!
@@ -24,7 +25,7 @@
 //!
 //! ```
 //! use ndtensors::Tensor;
-//! use ndtensors::decomposition::{svd, qr};
+//! use ndtensors::decomposition::{svd, qr, ql};
 //!
 //! // 3D tensor
 //! let t = Tensor::<f64>::ones(&[2, 3, 4]);
@@ -35,16 +36,23 @@
 //!
 //! // QR with same indices
 //! let qr_result = qr(&t, &[0, 1], &[2]).unwrap();
+//!
+//! // QL decomposition
+//! let ql_result = ql(&t, &[0, 1], &[2]).unwrap();
 //! ```
 
 mod exp;
 mod polar;
+mod positive;
+mod ql;
 mod qr;
 mod svd;
 mod util;
 
 pub use exp::matrix_exp;
 pub use polar::{PolarResult, polar};
+pub use positive::{ql_positive, qr_positive};
+pub use ql::{QlResult, ql};
 pub use qr::{QrResult, qr};
 pub use svd::{SvdResult, svd, svd_truncated};
 pub use util::{PermuteReshapeResult, permute_reshape};

--- a/crates/ndtensors/src/decomposition/positive.rs
+++ b/crates/ndtensors/src/decomposition/positive.rs
@@ -1,0 +1,492 @@
+//! Positive QR and QL decompositions.
+//!
+//! This module provides QR and QL decompositions where the diagonal elements
+//! of R or L are guaranteed to be non-negative and real. This makes the
+//! decomposition unique.
+
+use crate::decomposition::ql::{QlResult, ql};
+use crate::decomposition::qr::{QrResult, qr};
+use crate::error::TensorError;
+use crate::scalar::{RealScalar, Scalar};
+use crate::tensor::DenseTensor;
+
+/// Compute the QR decomposition with non-negative diagonal of R.
+///
+/// This computes the thin QR decomposition and then adjusts the signs
+/// of the columns of Q and rows of R so that the diagonal elements of R
+/// are non-negative (and real for complex types).
+///
+/// This makes the QR decomposition unique.
+///
+/// # Arguments
+///
+/// * `tensor` - The input tensor
+/// * `left_inds` - Indices to place on the left (become Q's row dimensions)
+/// * `right_inds` - Indices to place on the right (become R's column dimensions)
+///
+/// # Returns
+///
+/// `QrResult` with non-negative diagonal in R.
+///
+/// # Example
+///
+/// ```
+/// use ndtensors::Tensor;
+/// use ndtensors::decomposition::qr_positive;
+///
+/// let t = Tensor::<f64>::from_vec(vec![1.0, -2.0, 3.0, -4.0, 5.0, -6.0], &[2, 3]).unwrap();
+/// let result = qr_positive(&t, &[0], &[1]).unwrap();
+///
+/// // Check that diagonal of R is non-negative
+/// let k = result.rank;
+/// for i in 0..k {
+///     let r_ii = *result.r.get(&[i, i]).unwrap();
+///     assert!(r_ii >= 0.0, "R[{}, {}] = {} should be non-negative", i, i, r_ii);
+/// }
+/// ```
+pub fn qr_positive<ElT: Scalar>(
+    tensor: &DenseTensor<ElT>,
+    left_inds: &[usize],
+    right_inds: &[usize],
+) -> Result<QrResult<ElT>, TensorError>
+where
+    <ElT as Scalar>::Real: RealScalar,
+{
+    let result = qr(tensor, left_inds, right_inds)?;
+    Ok(make_qr_positive(result))
+}
+
+/// Make QR decomposition positive by adjusting signs.
+fn make_qr_positive<ElT: Scalar>(mut result: QrResult<ElT>) -> QrResult<ElT>
+where
+    <ElT as Scalar>::Real: RealScalar,
+{
+    let k = result.rank;
+    let q_shape = result.q.shape().to_vec();
+    let r_shape = result.r.shape().to_vec();
+
+    // Flatten dimensions for easier access
+    let m: usize = q_shape[..q_shape.len() - 1].iter().product();
+    let n: usize = r_shape[1..].iter().product();
+
+    for j in 0..k {
+        // Get diagonal element R[j, j]
+        let r_jj = *result.r.get_linear(j + j * k).unwrap();
+
+        // Compute sign (for complex: phase factor to make it real and non-negative)
+        let (sign_q, sign_r) = compute_sign(r_jj);
+
+        // If sign is already positive (or zero), no adjustment needed
+        if is_positive_real(r_jj) {
+            continue;
+        }
+
+        // Adjust column j of Q: Q[:, j] *= sign_q
+        for i in 0..m {
+            let idx = i + j * m;
+            let q_ij = *result.q.get_linear(idx).unwrap();
+            *result.q.get_linear_mut(idx).unwrap() = mul(q_ij, sign_q);
+        }
+
+        // Adjust row j of R: R[j, :] *= sign_r
+        for l in 0..n {
+            let idx = j + l * k;
+            let r_jl = *result.r.get_linear(idx).unwrap();
+            *result.r.get_linear_mut(idx).unwrap() = mul(r_jl, sign_r);
+        }
+    }
+
+    result
+}
+
+/// Compute the QL decomposition with non-negative diagonal of L.
+///
+/// This computes the thin QL decomposition and then adjusts the signs
+/// of the columns of Q and rows of L so that the diagonal elements of L
+/// are non-negative (and real for complex types).
+///
+/// This makes the QL decomposition unique.
+///
+/// # Arguments
+///
+/// * `tensor` - The input tensor
+/// * `left_inds` - Indices to place on the left (become Q's row dimensions)
+/// * `right_inds` - Indices to place on the right (become L's column dimensions)
+///
+/// # Returns
+///
+/// `QlResult` with non-negative diagonal in L.
+///
+/// # Example
+///
+/// ```
+/// use ndtensors::Tensor;
+/// use ndtensors::decomposition::ql_positive;
+///
+/// let t = Tensor::<f64>::from_vec(vec![1.0, -2.0, 3.0, -4.0, 5.0, -6.0], &[2, 3]).unwrap();
+/// let result = ql_positive(&t, &[0], &[1]).unwrap();
+///
+/// // Check that diagonal of L is non-negative
+/// // For QL, diagonal is L[i, n - k + i] for i in 0..k
+/// let k = result.rank;
+/// let n = result.l.shape()[1];
+/// for i in 0..k {
+///     let l_ii = *result.l.get(&[i, n - k + i]).unwrap();
+///     assert!(l_ii >= 0.0, "L[{}, {}] = {} should be non-negative", i, n - k + i, l_ii);
+/// }
+/// ```
+pub fn ql_positive<ElT: Scalar>(
+    tensor: &DenseTensor<ElT>,
+    left_inds: &[usize],
+    right_inds: &[usize],
+) -> Result<QlResult<ElT>, TensorError>
+where
+    <ElT as Scalar>::Real: RealScalar,
+{
+    let result = ql(tensor, left_inds, right_inds)?;
+    Ok(make_ql_positive(result))
+}
+
+/// Make QL decomposition positive by adjusting signs.
+fn make_ql_positive<ElT: Scalar>(mut result: QlResult<ElT>) -> QlResult<ElT>
+where
+    <ElT as Scalar>::Real: RealScalar,
+{
+    let k = result.rank;
+    let q_shape = result.q.shape().to_vec();
+    let l_shape = result.l.shape().to_vec();
+
+    // Flatten dimensions
+    let m: usize = q_shape[..q_shape.len() - 1].iter().product();
+    let n: usize = l_shape[1..].iter().product();
+
+    // For QL, diagonal elements are at L[i, n - k + i] for i in 0..min(k, n)
+    let diag_offset = n.saturating_sub(k);
+
+    for i in 0..k.min(n) {
+        let diag_col = diag_offset + i;
+        if diag_col >= n {
+            continue;
+        }
+
+        // Get diagonal element L[i, diag_col]
+        let l_ii = *result.l.get_linear(i + diag_col * k).unwrap();
+
+        // If sign is already positive (or zero), no adjustment needed
+        if is_positive_real(l_ii) {
+            continue;
+        }
+
+        // Compute sign
+        let (sign_q, sign_l) = compute_sign(l_ii);
+
+        // Adjust column i of Q: Q[:, i] *= sign_q
+        for r in 0..m {
+            let idx = r + i * m;
+            let q_ri = *result.q.get_linear(idx).unwrap();
+            *result.q.get_linear_mut(idx).unwrap() = mul(q_ri, sign_q);
+        }
+
+        // Adjust row i of L from column 0 to diag_col (inclusive): L[i, 0:diag_col+1] *= sign_l
+        for c in 0..=diag_col {
+            let idx = i + c * k;
+            let l_ic = *result.l.get_linear(idx).unwrap();
+            *result.l.get_linear_mut(idx).unwrap() = mul(l_ic, sign_l);
+        }
+    }
+
+    result
+}
+
+/// Check if a scalar is positive real (non-negative real part, zero imaginary part).
+fn is_positive_real<ElT: Scalar>(x: ElT) -> bool
+where
+    <ElT as Scalar>::Real: RealScalar,
+{
+    let re = x.real_part().to_f64();
+    let im = x.imag_part().to_f64();
+
+    // Check if imaginary part is essentially zero and real part is non-negative
+    im.abs() < 1e-14 && re >= -1e-14
+}
+
+/// Compute the sign factors to make a diagonal element non-negative real.
+/// Returns (sign_q, sign_r) such that:
+/// - x * sign_r = |x| (real, non-negative)
+/// - sign_q = conj(sign_r) to preserve Q*R product
+fn compute_sign<ElT: Scalar>(x: ElT) -> (ElT, ElT)
+where
+    <ElT as Scalar>::Real: RealScalar,
+{
+    let re = x.real_part().to_f64();
+    let im = x.imag_part().to_f64();
+    let abs_x = (re * re + im * im).sqrt();
+
+    if abs_x < 1e-14 {
+        // Zero element, no adjustment needed
+        return (ElT::one(), ElT::one());
+    }
+
+    use faer_traits::math_utils::{from_f64, mul as faer_mul};
+
+    // unit_phase = x / |x|
+    let inv_abs: ElT = from_f64(1.0 / abs_x);
+    let unit_phase = faer_mul(&x, &inv_abs);
+
+    // sign_r = conj(x) / |x| = conj(unit_phase)
+    // so that x * sign_r = x * conj(x) / |x| = |x|² / |x| = |x|
+    let sign_r = unit_phase.conjugate();
+
+    // sign_q = conj(sign_r) = unit_phase
+    // so that Q' * R' = (Q * sign_q) * (sign_r * R) = Q * R (signs cancel)
+    let sign_q = unit_phase;
+
+    (sign_q, sign_r)
+}
+
+/// Multiply two scalars.
+fn mul<ElT: Scalar>(a: ElT, b: ElT) -> ElT {
+    use faer_traits::math_utils::mul as faer_mul;
+    faer_mul(&a, &b)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scalar::c64;
+
+    fn check_reconstruction_qr<
+        ElT: Scalar + std::ops::Add<Output = ElT> + std::ops::Mul<Output = ElT>,
+    >(
+        result: &QrResult<ElT>,
+        original: &DenseTensor<ElT>,
+        epsilon: f64,
+    ) {
+        use crate::contract::contract;
+
+        // Contract Q with R
+        let q_ndim = result.q.ndim();
+        let r_ndim = result.r.ndim();
+
+        let mut q_labels: Vec<i32> = (1..q_ndim as i32).collect();
+        q_labels.push(-1);
+
+        let mut r_labels = vec![-1];
+        for i in 0..(r_ndim - 1) {
+            r_labels.push((q_ndim + i) as i32);
+        }
+
+        let reconstructed = contract(&result.q, &q_labels, &result.r, &r_labels).unwrap();
+
+        for i in 0..original.len() {
+            let orig = *original.get_linear(i).unwrap();
+            let recon = *reconstructed.get_linear(i).unwrap();
+            let diff = (orig.real_part().to_f64() - recon.real_part().to_f64()).abs()
+                + (orig.imag_part().to_f64() - recon.imag_part().to_f64()).abs();
+            assert!(
+                diff < epsilon,
+                "Reconstruction failed at index {}: orig={:?}, recon={:?}",
+                i,
+                orig,
+                recon
+            );
+        }
+    }
+
+    fn check_reconstruction_ql<
+        ElT: Scalar + std::ops::Add<Output = ElT> + std::ops::Mul<Output = ElT>,
+    >(
+        result: &QlResult<ElT>,
+        original: &DenseTensor<ElT>,
+        epsilon: f64,
+    ) {
+        use crate::contract::contract;
+
+        let q_ndim = result.q.ndim();
+        let l_ndim = result.l.ndim();
+
+        let mut q_labels: Vec<i32> = (1..q_ndim as i32).collect();
+        q_labels.push(-1);
+
+        let mut l_labels = vec![-1];
+        for i in 0..(l_ndim - 1) {
+            l_labels.push((q_ndim + i) as i32);
+        }
+
+        let reconstructed = contract(&result.q, &q_labels, &result.l, &l_labels).unwrap();
+
+        for i in 0..original.len() {
+            let orig = *original.get_linear(i).unwrap();
+            let recon = *reconstructed.get_linear(i).unwrap();
+            let diff = (orig.real_part().to_f64() - recon.real_part().to_f64()).abs()
+                + (orig.imag_part().to_f64() - recon.imag_part().to_f64()).abs();
+            assert!(
+                diff < epsilon,
+                "Reconstruction failed at index {}: orig={:?}, recon={:?}",
+                i,
+                orig,
+                recon
+            );
+        }
+    }
+
+    #[test]
+    fn test_qr_positive_f64() {
+        let t = DenseTensor::from_vec(vec![1.0, -2.0, 3.0, -4.0, 5.0, -6.0], &[2, 3]).unwrap();
+        let result = qr_positive(&t, &[0], &[1]).unwrap();
+
+        // Check diagonal of R is non-negative
+        let k = result.rank;
+        for i in 0..k {
+            let r_ii = *result.r.get(&[i, i]).unwrap();
+            assert!(
+                r_ii >= -1e-14,
+                "R[{}, {}] = {} should be non-negative",
+                i,
+                i,
+                r_ii
+            );
+        }
+
+        // Check reconstruction
+        check_reconstruction_qr(&result, &t, 1e-10);
+    }
+
+    #[test]
+    fn test_qr_positive_c64() {
+        let t = DenseTensor::from_vec(
+            vec![
+                c64::new(1.0, -1.0),
+                c64::new(-2.0, 2.0),
+                c64::new(3.0, -3.0),
+                c64::new(-4.0, 4.0),
+                c64::new(5.0, -5.0),
+                c64::new(-6.0, 6.0),
+            ],
+            &[2, 3],
+        )
+        .unwrap();
+        let result = qr_positive(&t, &[0], &[1]).unwrap();
+
+        // Check diagonal of R is non-negative real
+        let k = result.rank;
+        for i in 0..k {
+            let r_ii = *result.r.get(&[i, i]).unwrap();
+            assert!(
+                r_ii.re >= -1e-14,
+                "R[{}, {}].re = {} should be non-negative",
+                i,
+                i,
+                r_ii.re
+            );
+            assert!(
+                r_ii.im.abs() < 1e-10,
+                "R[{}, {}].im = {} should be zero",
+                i,
+                i,
+                r_ii.im
+            );
+        }
+
+        // Check reconstruction
+        check_reconstruction_qr(&result, &t, 1e-10);
+    }
+
+    #[test]
+    fn test_ql_positive_f64() {
+        let t = DenseTensor::from_vec(vec![1.0, -2.0, 3.0, -4.0, 5.0, -6.0], &[2, 3]).unwrap();
+        let result = ql_positive(&t, &[0], &[1]).unwrap();
+
+        // Check diagonal of L is non-negative
+        let k = result.rank;
+        let n = result.l.shape()[1];
+        for i in 0..k {
+            let diag_col = n - k + i;
+            let l_ii = *result.l.get(&[i, diag_col]).unwrap();
+            assert!(
+                l_ii >= -1e-14,
+                "L[{}, {}] = {} should be non-negative",
+                i,
+                diag_col,
+                l_ii
+            );
+        }
+
+        // Check reconstruction
+        check_reconstruction_ql(&result, &t, 1e-10);
+    }
+
+    #[test]
+    fn test_ql_positive_c64() {
+        let t = DenseTensor::from_vec(
+            vec![
+                c64::new(1.0, -1.0),
+                c64::new(-2.0, 2.0),
+                c64::new(3.0, -3.0),
+                c64::new(-4.0, 4.0),
+                c64::new(5.0, -5.0),
+                c64::new(-6.0, 6.0),
+            ],
+            &[2, 3],
+        )
+        .unwrap();
+        let result = ql_positive(&t, &[0], &[1]).unwrap();
+
+        // Check diagonal of L is non-negative real
+        let k = result.rank;
+        let n = result.l.shape()[1];
+        for i in 0..k {
+            let diag_col = n - k + i;
+            let l_ii = *result.l.get(&[i, diag_col]).unwrap();
+            assert!(
+                l_ii.re >= -1e-14,
+                "L[{}, {}].re = {} should be non-negative",
+                i,
+                diag_col,
+                l_ii.re
+            );
+            assert!(
+                l_ii.im.abs() < 1e-10,
+                "L[{}, {}].im = {} should be zero",
+                i,
+                diag_col,
+                l_ii.im
+            );
+        }
+
+        // Check reconstruction
+        check_reconstruction_ql(&result, &t, 1e-10);
+    }
+
+    #[test]
+    fn test_qr_positive_tall() {
+        let t = DenseTensor::from_vec(vec![1.0, -2.0, 3.0, -4.0, 5.0, -6.0, 7.0, -8.0], &[4, 2])
+            .unwrap();
+        let result = qr_positive(&t, &[0], &[1]).unwrap();
+
+        let k = result.rank;
+        for i in 0..k {
+            let r_ii = *result.r.get(&[i, i]).unwrap();
+            assert!(r_ii >= -1e-14);
+        }
+
+        check_reconstruction_qr(&result, &t, 1e-10);
+    }
+
+    #[test]
+    fn test_ql_positive_wide() {
+        let t = DenseTensor::from_vec(vec![1.0, -2.0, 3.0, -4.0, 5.0, -6.0, 7.0, -8.0], &[2, 4])
+            .unwrap();
+        let result = ql_positive(&t, &[0], &[1]).unwrap();
+
+        let k = result.rank;
+        let n = result.l.shape()[1];
+        for i in 0..k {
+            let diag_col = n - k + i;
+            let l_ii = *result.l.get(&[i, diag_col]).unwrap();
+            assert!(l_ii >= -1e-14);
+        }
+
+        check_reconstruction_ql(&result, &t, 1e-10);
+    }
+}

--- a/crates/ndtensors/src/decomposition/ql.rs
+++ b/crates/ndtensors/src/decomposition/ql.rs
@@ -1,0 +1,369 @@
+//! QL Decomposition for tensors.
+//!
+//! This module provides QL decomposition for tensors by reshaping them
+//! to matrices, computing the QL using a custom implementation based on
+//! LAPACK's geqlf, and reshaping the results.
+
+use crate::decomposition::util::{PermuteReshapeResult, permute_reshape};
+use crate::error::TensorError;
+use crate::scalar::Scalar;
+use crate::tensor::DenseTensor;
+
+/// Result of QL decomposition.
+#[derive(Debug, Clone)]
+pub struct QlResult<ElT: Scalar> {
+    /// Orthogonal/unitary matrix Q reshaped to tensor form.
+    /// Shape: [...left_dims..., k] where k = min(m, n)
+    pub q: DenseTensor<ElT>,
+
+    /// Lower triangular matrix L reshaped to tensor form.
+    /// Shape: [k, ...right_dims...] where k = min(m, n)
+    pub l: DenseTensor<ElT>,
+
+    /// The rank k = min(m, n)
+    pub rank: usize,
+}
+
+/// Compute the thin QL decomposition of a tensor.
+///
+/// The tensor is reshaped into a matrix by grouping the specified left indices
+/// into rows and right indices into columns. The QL decomposition is then computed
+/// and the results are reshaped back to tensor form.
+///
+/// For a matrix A of shape (m, n), the thin QL produces:
+/// - Q: (m, k) where k = min(m, n), with orthonormal columns
+/// - L: (k, n), lower triangular (zeros in upper right)
+///
+/// Such that A = Q @ L.
+///
+/// # Arguments
+///
+/// * `tensor` - The input tensor
+/// * `left_inds` - Indices to place on the left (become Q's row dimensions)
+/// * `right_inds` - Indices to place on the right (become L's column dimensions)
+///
+/// # Returns
+///
+/// `QlResult` containing:
+/// - `q`: Orthogonal factor with shape [...left_dims..., k]
+/// - `l`: Lower triangular factor with shape [k, ...right_dims...]
+/// - `rank`: k = min(m, n)
+///
+/// # Example
+///
+/// ```
+/// use ndtensors::Tensor;
+/// use ndtensors::decomposition::ql;
+///
+/// let t = Tensor::<f64>::ones(&[4, 3]);
+/// let result = ql(&t, &[0], &[1]).unwrap();
+///
+/// // Q has shape [4, 3], L has shape [3, 3]
+/// assert_eq!(result.q.shape(), &[4, 3]);
+/// assert_eq!(result.l.shape(), &[3, 3]);
+/// ```
+pub fn ql<ElT: Scalar>(
+    tensor: &DenseTensor<ElT>,
+    left_inds: &[usize],
+    right_inds: &[usize],
+) -> Result<QlResult<ElT>, TensorError> {
+    // Permute and reshape to matrix
+    let PermuteReshapeResult {
+        matrix,
+        nrows,
+        ncols,
+        left_dims,
+        right_dims,
+        ..
+    } = permute_reshape(tensor, left_inds, right_inds)?;
+
+    let m = nrows;
+    let n = ncols;
+    let k = m.min(n);
+
+    // Compute QL decomposition using custom implementation
+    let (q_data, l_data) = ql_decomp(matrix.data(), m, n);
+
+    // Reshape Q to [...left_dims..., k]
+    let mut q_shape = left_dims;
+    q_shape.push(k);
+    let q = DenseTensor::from_vec(q_data, &q_shape)?;
+
+    // Reshape L to [k, ...right_dims...]
+    let mut l_shape = vec![k];
+    l_shape.extend(right_dims);
+    let l = DenseTensor::from_vec(l_data, &l_shape)?;
+
+    Ok(QlResult { q, l, rank: k })
+}
+
+/// Compute QL decomposition of a matrix stored in column-major order.
+/// Returns (Q_data, L_data) both in column-major order.
+fn ql_decomp<ElT: Scalar>(data: &[ElT], m: usize, n: usize) -> (Vec<ElT>, Vec<ElT>) {
+    use faer::MatRef;
+    use faer::linalg::solvers::Qr;
+
+    let k = m.min(n);
+
+    // QL decomposition: A = Q * L where L is lower triangular (from the right)
+    // We compute this by: reverse columns of A, do QR, reverse columns of Q and both dims of R
+    //
+    // Alternatively, use the relationship with QR:
+    // A = Q * L  where L is lower triangular
+    // A^T = L^T * Q^T where L^T is upper triangular
+    // So we can: transpose A, do QR, then transpose results
+
+    // For simplicity, we'll use the column-reversal approach:
+    // 1. Reverse column order of A: A_rev[:, j] = A[:, n-1-j]
+    // 2. Compute QR: A_rev = Q_rev * R_rev
+    // 3. Q[:, j] = Q_rev[:, k-1-j]
+    // 4. L[i, j] = R_rev[k-1-i, n-1-j]
+
+    // Create reversed matrix (column-major)
+    let mut a_rev = vec![ElT::zero(); m * n];
+    for j in 0..n {
+        for i in 0..m {
+            // a_rev[i, j] = a[i, n-1-j]
+            a_rev[i + j * m] = data[i + (n - 1 - j) * m];
+        }
+    }
+
+    // Compute QR using faer
+    let mat = MatRef::from_column_major_slice(&a_rev, m, n);
+    let qr_result: Qr<ElT> = Qr::new(mat);
+
+    let q_rev = qr_result.compute_thin_Q();
+    let r_rev = qr_result.thin_R();
+
+    // Extract Q with reversed columns
+    let mut q_data = Vec::with_capacity(m * k);
+    for j in 0..k {
+        for i in 0..m {
+            q_data.push(q_rev[(i, k - 1 - j)]);
+        }
+    }
+
+    // Extract L with reversed rows and columns
+    // L has shape (k, n), lower triangular from the right
+    // L[i, j] = R_rev[k-1-i, n-1-j]
+    let mut l_data = Vec::with_capacity(k * n);
+    for j in 0..n {
+        for i in 0..k {
+            l_data.push(r_rev[(k - 1 - i, n - 1 - j)]);
+        }
+    }
+
+    (q_data, l_data)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+    use faer_traits::ComplexField;
+    use faer_traits::math_utils::{abs, conj, from_f64, neg};
+    use std::ops::{Add, Mul};
+
+    fn reconstruct<ElT: Scalar + Add<Output = ElT> + Mul<Output = ElT>>(
+        result: &QlResult<ElT>,
+        original_shape: &[usize],
+        left_inds: &[usize],
+        right_inds: &[usize],
+    ) -> DenseTensor<ElT> {
+        use crate::contract::contract;
+
+        // Contract Q with L
+        let q_ndim = result.q.ndim();
+        let l_ndim = result.l.ndim();
+
+        // Labels for Q: [1, 2, ..., q_ndim-1, -1]
+        let mut q_labels: Vec<i32> = (1..q_ndim as i32).collect();
+        q_labels.push(-1);
+
+        // Labels for L: [-1, q_ndim, q_ndim+1, ...]
+        let mut l_labels = vec![-1];
+        for i in 0..(l_ndim - 1) {
+            l_labels.push((q_ndim + i) as i32);
+        }
+
+        let contracted = contract(&result.q, &q_labels, &result.l, &l_labels).unwrap();
+
+        // Build the inverse permutation
+        let perm: Vec<usize> = left_inds.iter().chain(right_inds.iter()).copied().collect();
+        let mut inv_perm = vec![0; perm.len()];
+        for (i, &p) in perm.iter().enumerate() {
+            inv_perm[p] = i;
+        }
+
+        // Reshape to permuted shape
+        let permuted_shape: Vec<usize> = left_inds
+            .iter()
+            .map(|&i| original_shape[i])
+            .chain(right_inds.iter().map(|&i| original_shape[i]))
+            .collect();
+
+        let reshaped = DenseTensor::from_vec(contracted.data().to_vec(), &permuted_shape).unwrap();
+
+        // Apply inverse permutation
+        use crate::operations::permutedims;
+        permutedims(&reshaped, &inv_perm).unwrap()
+    }
+
+    fn check_orthogonality<ElT: Scalar + Add<Output = ElT> + Mul<Output = ElT>>(
+        q: &DenseTensor<ElT>,
+        epsilon: f64,
+    ) {
+        // Q^H @ Q should be identity
+        let q_ndim = q.ndim();
+        let k = q.shape()[q_ndim - 1];
+
+        // Flatten Q to 2D: (m, k)
+        let m: usize = q.shape()[..q_ndim - 1].iter().product();
+
+        let eps: <ElT as ComplexField>::Real = from_f64(epsilon);
+
+        // Manual computation
+        for j in 0..k {
+            for l in 0..k {
+                let mut sum = ElT::zero();
+                for i in 0..m {
+                    let q_ij = *q.get_linear(j * m + i).unwrap();
+                    let q_il = *q.get_linear(l * m + i).unwrap();
+                    sum = sum + conj(&q_ij) * q_il;
+                }
+                let expected = if j == l { ElT::one() } else { ElT::zero() };
+                let diff: <ElT as ComplexField>::Real = abs(&(sum + neg(&expected)));
+                assert!(diff < eps, "Q^H @ Q should be identity at ({}, {})", j, l);
+            }
+        }
+    }
+
+    fn check_lower_triangular<ElT: Scalar>(l: &DenseTensor<ElT>, epsilon: f64) {
+        // L should be lower triangular (zeros in upper-right triangle)
+        // For QL, the "diagonal" starts from the right side
+        let k = l.shape()[0];
+        let n: usize = l.shape()[1..].iter().product();
+
+        let eps: <ElT as ComplexField>::Real = from_f64(epsilon);
+
+        // For a k x n matrix L in QL:
+        // If n >= k: upper triangle starts at column (n - k)
+        // If n < k: L is dense (no upper triangle zeros required by definition)
+
+        if n >= k {
+            for i in 0..k {
+                for j in (n - k + i + 1)..n {
+                    let val = *l.get_linear(i + j * k).unwrap();
+                    let val_abs: <ElT as ComplexField>::Real = abs(&val);
+                    assert!(
+                        val_abs < eps,
+                        "L should be lower triangular, but L[{}, {}] = {:?}",
+                        i,
+                        j,
+                        val
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_ql_2d() {
+        let t = DenseTensor::from_vec(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0], &[2, 3]).unwrap();
+        let result = ql(&t, &[0], &[1]).unwrap();
+
+        assert_eq!(result.q.shape(), &[2, 2]);
+        assert_eq!(result.l.shape(), &[2, 3]);
+        assert_eq!(result.rank, 2);
+
+        // Check orthogonality
+        check_orthogonality(&result.q, 1e-10);
+
+        // Check lower triangular
+        check_lower_triangular(&result.l, 1e-10);
+
+        // Reconstruct and compare
+        let reconstructed = reconstruct(&result, &[2, 3], &[0], &[1]);
+        assert_eq!(reconstructed.shape(), t.shape());
+
+        for i in 0..t.len() {
+            assert_relative_eq!(
+                *reconstructed.get_linear(i).unwrap(),
+                *t.get_linear(i).unwrap(),
+                epsilon = 1e-10
+            );
+        }
+    }
+
+    #[test]
+    fn test_ql_tall() {
+        let t =
+            DenseTensor::from_vec(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0], &[4, 2]).unwrap();
+        let result = ql(&t, &[0], &[1]).unwrap();
+
+        assert_eq!(result.q.shape(), &[4, 2]); // m=4, k=min(4,2)=2
+        assert_eq!(result.l.shape(), &[2, 2]); // k=2, n=2
+        assert_eq!(result.rank, 2);
+
+        // Check orthogonality
+        check_orthogonality(&result.q, 1e-10);
+
+        // Reconstruct and compare
+        let reconstructed = reconstruct(&result, &[4, 2], &[0], &[1]);
+        for i in 0..t.len() {
+            assert_relative_eq!(
+                *reconstructed.get_linear(i).unwrap(),
+                *t.get_linear(i).unwrap(),
+                epsilon = 1e-10
+            );
+        }
+    }
+
+    #[test]
+    fn test_ql_wide() {
+        let t =
+            DenseTensor::from_vec(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0], &[2, 4]).unwrap();
+        let result = ql(&t, &[0], &[1]).unwrap();
+
+        assert_eq!(result.q.shape(), &[2, 2]); // m=2, k=min(2,4)=2
+        assert_eq!(result.l.shape(), &[2, 4]); // k=2, n=4
+        assert_eq!(result.rank, 2);
+
+        // Check orthogonality
+        check_orthogonality(&result.q, 1e-10);
+
+        // Check lower triangular
+        check_lower_triangular(&result.l, 1e-10);
+
+        // Reconstruct and compare
+        let reconstructed = reconstruct(&result, &[2, 4], &[0], &[1]);
+        for i in 0..t.len() {
+            assert_relative_eq!(
+                *reconstructed.get_linear(i).unwrap(),
+                *t.get_linear(i).unwrap(),
+                epsilon = 1e-10
+            );
+        }
+    }
+
+    #[test]
+    fn test_ql_3d() {
+        let t = DenseTensor::<f64>::ones(&[2, 3, 4]);
+        let result = ql(&t, &[0, 1], &[2]).unwrap();
+
+        // m = 2*3 = 6, n = 4, k = min(6, 4) = 4
+        assert_eq!(result.q.shape(), &[2, 3, 4]);
+        assert_eq!(result.l.shape(), &[4, 4]);
+        assert_eq!(result.rank, 4);
+
+        // Reconstruct and compare
+        let reconstructed = reconstruct(&result, &[2, 3, 4], &[0, 1], &[2]);
+        for i in 0..t.len() {
+            assert_relative_eq!(
+                *reconstructed.get_linear(i).unwrap(),
+                *t.get_linear(i).unwrap(),
+                epsilon = 1e-10
+            );
+        }
+    }
+}

--- a/crates/ndtensors/tests/test_linearalgebra.rs
+++ b/crates/ndtensors/tests/test_linearalgebra.rs
@@ -1,0 +1,559 @@
+//! Tests for linear algebra utilities.
+//!
+//! These tests mirror NDTensors.jl's test_linearalgebra.jl, covering:
+//! - random_orthog: Random orthogonal matrix generation
+//! - random_unitary: Random unitary matrix generation
+//! - QR decomposition with positive factorization mode
+//! - QL decomposition with positive factorization mode
+
+use approx::assert_relative_eq;
+use ndtensors::Tensor;
+use ndtensors::c64;
+use ndtensors::decomposition::{ql, ql_positive, qr, qr_positive};
+use ndtensors::random::{random_orthog, random_unitary};
+
+/// Test random_orthog generates matrices with orthonormal columns (tall) or rows (wide).
+/// Mirrors: @testset "random_orthog" from test_linearalgebra.jl
+#[test]
+fn test_random_orthog() {
+    let (n, m) = (10, 4);
+
+    // Tall matrix: O^T * O should be I_m
+    let o1 = random_orthog(n, m);
+    assert_eq!(o1.shape(), &[n, m]);
+
+    // Check O1^T * O1 ≈ I_m
+    for i in 0..m {
+        for j in 0..m {
+            let mut sum = 0.0;
+            for k in 0..n {
+                sum += o1.get(&[k, i]).unwrap() * o1.get(&[k, j]).unwrap();
+            }
+            let expected = if i == j { 1.0 } else { 0.0 };
+            assert_relative_eq!(sum, expected, epsilon = 1e-14);
+        }
+    }
+
+    // Wide matrix: O * O^T should be I_m
+    let o2 = random_orthog(m, n);
+    assert_eq!(o2.shape(), &[m, n]);
+
+    // Check O2 * O2^T ≈ I_m
+    for i in 0..m {
+        for j in 0..m {
+            let mut sum = 0.0;
+            for k in 0..n {
+                sum += o2.get(&[i, k]).unwrap() * o2.get(&[j, k]).unwrap();
+            }
+            let expected = if i == j { 1.0 } else { 0.0 };
+            assert_relative_eq!(sum, expected, epsilon = 1e-14);
+        }
+    }
+}
+
+/// Test random_unitary generates matrices with orthonormal columns (tall) or rows (wide).
+/// Mirrors: @testset "random_unitary" from test_linearalgebra.jl
+#[test]
+fn test_random_unitary() {
+    let (n, m) = (10, 4);
+
+    // Tall matrix: U^H * U should be I_m
+    let u1 = random_unitary(n, m);
+    assert_eq!(u1.shape(), &[n, m]);
+
+    // Check U1^H * U1 ≈ I_m
+    for i in 0..m {
+        for j in 0..m {
+            let mut sum = c64::new(0.0, 0.0);
+            for k in 0..n {
+                let u_ki = *u1.get(&[k, i]).unwrap();
+                let u_kj = *u1.get(&[k, j]).unwrap();
+                // U^H means conjugate transpose
+                sum = c64::new(
+                    sum.re + u_ki.re * u_kj.re + u_ki.im * u_kj.im,
+                    sum.im + u_ki.re * u_kj.im - u_ki.im * u_kj.re,
+                );
+            }
+            let expected_re = if i == j { 1.0 } else { 0.0 };
+            assert_relative_eq!(sum.re, expected_re, epsilon = 1e-14);
+            assert_relative_eq!(sum.im, 0.0, epsilon = 1e-14);
+        }
+    }
+
+    // Wide matrix: U * U^H should be I_m
+    let u2 = random_unitary(m, n);
+    assert_eq!(u2.shape(), &[m, n]);
+
+    // Check U2 * U2^H ≈ I_m
+    for i in 0..m {
+        for j in 0..m {
+            let mut sum = c64::new(0.0, 0.0);
+            for k in 0..n {
+                let u_ik = *u2.get(&[i, k]).unwrap();
+                let u_jk = *u2.get(&[j, k]).unwrap();
+                // U * U^H: sum over u_ik * conj(u_jk)
+                sum = c64::new(
+                    sum.re + u_ik.re * u_jk.re + u_ik.im * u_jk.im,
+                    sum.im + u_ik.im * u_jk.re - u_ik.re * u_jk.im,
+                );
+            }
+            let expected_re = if i == j { 1.0 } else { 0.0 };
+            assert_relative_eq!(sum.re, expected_re, epsilon = 1e-14);
+            assert_relative_eq!(sum.im, 0.0, epsilon = 1e-14);
+        }
+    }
+}
+
+/// Generic test for QX (QR or QL) decompositions.
+/// Mirrors: @testset "QX testing" from test_linearalgebra.jl
+mod qx_tests {
+    use super::*;
+    use ndtensors::contract::contract;
+    use ndtensors::decomposition::{QlResult, QrResult};
+    use ndtensors::scalar::{RealScalar, Scalar};
+
+    /// Check Q^H * Q ≈ I
+    fn check_orthogonality<ElT: Scalar>(q: &Tensor<ElT>, epsilon: f64)
+    where
+        <ElT as Scalar>::Real: RealScalar,
+    {
+        let q_shape = q.shape();
+        let m: usize = q_shape[..q_shape.len() - 1].iter().product();
+        let k = q_shape[q_shape.len() - 1];
+
+        for i in 0..k {
+            for j in 0..k {
+                let mut sum_re = 0.0;
+                let mut sum_im = 0.0;
+                for r in 0..m {
+                    let q_ri = *q.get_linear(r + i * m).unwrap();
+                    let q_rj = *q.get_linear(r + j * m).unwrap();
+                    // conj(q_ri) * q_rj
+                    sum_re += q_ri.real_part().to_f64() * q_rj.real_part().to_f64()
+                        + q_ri.imag_part().to_f64() * q_rj.imag_part().to_f64();
+                    sum_im += q_ri.real_part().to_f64() * q_rj.imag_part().to_f64()
+                        - q_ri.imag_part().to_f64() * q_rj.real_part().to_f64();
+                }
+                let expected_re = if i == j { 1.0 } else { 0.0 };
+                assert!(
+                    (sum_re - expected_re).abs() < epsilon,
+                    "Q^H*Q[{},{}] real part: {} != {}",
+                    i,
+                    j,
+                    sum_re,
+                    expected_re
+                );
+                assert!(
+                    sum_im.abs() < epsilon,
+                    "Q^H*Q[{},{}] imag part: {} != 0",
+                    i,
+                    j,
+                    sum_im
+                );
+            }
+        }
+    }
+
+    /// Check that Q * Q^H ≈ I (for square Q)
+    fn check_orthogonality_full<ElT: Scalar>(q: &Tensor<ElT>, epsilon: f64)
+    where
+        <ElT as Scalar>::Real: RealScalar,
+    {
+        let q_shape = q.shape();
+        let m: usize = q_shape[..q_shape.len() - 1].iter().product();
+        let k = q_shape[q_shape.len() - 1];
+
+        if m != k {
+            return; // Only check for square Q
+        }
+
+        for i in 0..m {
+            for j in 0..m {
+                let mut sum_re = 0.0;
+                let mut sum_im = 0.0;
+                for c in 0..k {
+                    let q_ic = *q.get_linear(i + c * m).unwrap();
+                    let q_jc = *q.get_linear(j + c * m).unwrap();
+                    // q_ic * conj(q_jc)
+                    sum_re += q_ic.real_part().to_f64() * q_jc.real_part().to_f64()
+                        + q_ic.imag_part().to_f64() * q_jc.imag_part().to_f64();
+                    sum_im += q_ic.imag_part().to_f64() * q_jc.real_part().to_f64()
+                        - q_ic.real_part().to_f64() * q_jc.imag_part().to_f64();
+                }
+                let expected_re = if i == j { 1.0 } else { 0.0 };
+                assert!(
+                    (sum_re - expected_re).abs() < epsilon,
+                    "Q*Q^H[{},{}] real part: {} != {}",
+                    i,
+                    j,
+                    sum_re,
+                    expected_re
+                );
+                assert!(
+                    sum_im.abs() < epsilon,
+                    "Q*Q^H[{},{}] imag part: {} != 0",
+                    i,
+                    j,
+                    sum_im
+                );
+            }
+        }
+    }
+
+    /// Check reconstruction A ≈ Q * X
+    fn check_reconstruction_qr<
+        ElT: Scalar + std::ops::Add<Output = ElT> + std::ops::Mul<Output = ElT>,
+    >(
+        result: &QrResult<ElT>,
+        original: &Tensor<ElT>,
+        epsilon: f64,
+    ) where
+        <ElT as Scalar>::Real: RealScalar,
+    {
+        let q_ndim = result.q.ndim();
+        let r_ndim = result.r.ndim();
+
+        let mut q_labels: Vec<i32> = (1..q_ndim as i32).collect();
+        q_labels.push(-1);
+
+        let mut r_labels = vec![-1];
+        for i in 0..(r_ndim - 1) {
+            r_labels.push((q_ndim + i) as i32);
+        }
+
+        let reconstructed = contract(&result.q, &q_labels, &result.r, &r_labels).unwrap();
+
+        for i in 0..original.len() {
+            let orig = *original.get_linear(i).unwrap();
+            let recon = *reconstructed.get_linear(i).unwrap();
+            let diff = (orig.real_part().to_f64() - recon.real_part().to_f64()).abs()
+                + (orig.imag_part().to_f64() - recon.imag_part().to_f64()).abs();
+            assert!(
+                diff < epsilon,
+                "Reconstruction QR failed at {}: orig={:?}, recon={:?}",
+                i,
+                orig,
+                recon
+            );
+        }
+    }
+
+    fn check_reconstruction_ql<
+        ElT: Scalar + std::ops::Add<Output = ElT> + std::ops::Mul<Output = ElT>,
+    >(
+        result: &QlResult<ElT>,
+        original: &Tensor<ElT>,
+        epsilon: f64,
+    ) where
+        <ElT as Scalar>::Real: RealScalar,
+    {
+        let q_ndim = result.q.ndim();
+        let l_ndim = result.l.ndim();
+
+        let mut q_labels: Vec<i32> = (1..q_ndim as i32).collect();
+        q_labels.push(-1);
+
+        let mut l_labels = vec![-1];
+        for i in 0..(l_ndim - 1) {
+            l_labels.push((q_ndim + i) as i32);
+        }
+
+        let reconstructed = contract(&result.q, &q_labels, &result.l, &l_labels).unwrap();
+
+        for i in 0..original.len() {
+            let orig = *original.get_linear(i).unwrap();
+            let recon = *reconstructed.get_linear(i).unwrap();
+            let diff = (orig.real_part().to_f64() - recon.real_part().to_f64()).abs()
+                + (orig.imag_part().to_f64() - recon.imag_part().to_f64()).abs();
+            assert!(
+                diff < epsilon,
+                "Reconstruction QL failed at {}: orig={:?}, recon={:?}",
+                i,
+                orig,
+                recon
+            );
+        }
+    }
+
+    /// Check positive diagonal for QR
+    fn check_positive_diagonal_qr<ElT: Scalar>(result: &QrResult<ElT>)
+    where
+        <ElT as Scalar>::Real: RealScalar,
+    {
+        let k = result.rank;
+        for i in 0..k {
+            let r_ii = *result.r.get(&[i, i]).unwrap();
+            assert!(
+                r_ii.real_part().to_f64() >= -1e-10,
+                "R[{},{}].re = {} should be non-negative",
+                i,
+                i,
+                r_ii.real_part().to_f64()
+            );
+            assert!(
+                r_ii.imag_part().to_f64().abs() < 1e-10,
+                "R[{},{}].im = {} should be zero",
+                i,
+                i,
+                r_ii.imag_part().to_f64()
+            );
+        }
+    }
+
+    /// Check positive diagonal for QL
+    fn check_positive_diagonal_ql<ElT: Scalar>(result: &QlResult<ElT>)
+    where
+        <ElT as Scalar>::Real: RealScalar,
+    {
+        let k = result.rank;
+        let n = result.l.shape()[1];
+        let diag_offset = n.saturating_sub(k);
+
+        for i in 0..k.min(n) {
+            let diag_col = diag_offset + i;
+            if diag_col >= n {
+                continue;
+            }
+            let l_ii = *result.l.get(&[i, diag_col]).unwrap();
+            assert!(
+                l_ii.real_part().to_f64() >= -1e-10,
+                "L[{},{}].re = {} should be non-negative",
+                i,
+                diag_col,
+                l_ii.real_part().to_f64()
+            );
+            assert!(
+                l_ii.imag_part().to_f64().abs() < 1e-10,
+                "L[{},{}].im = {} should be zero",
+                i,
+                diag_col,
+                l_ii.imag_part().to_f64()
+            );
+        }
+    }
+
+    // ========== QR Tests ==========
+
+    #[test]
+    fn test_qr_f64_wide_positive() {
+        let eps = f64::EPSILON * 100.0;
+        let (n, m) = (4, 8);
+        let a: Tensor<f64> = Tensor::randn(&[n, m]);
+
+        let result = qr_positive(&a, &[0], &[1]).unwrap();
+        check_reconstruction_qr(&result, &a, eps);
+        check_orthogonality(&result.q, eps);
+        check_orthogonality_full(&result.q, eps);
+        check_positive_diagonal_qr(&result);
+    }
+
+    #[test]
+    fn test_qr_f64_tall_positive() {
+        let eps = f64::EPSILON * 100.0;
+        let (n, m) = (8, 4);
+        let a: Tensor<f64> = Tensor::randn(&[n, m]);
+
+        let result = qr_positive(&a, &[0], &[1]).unwrap();
+        check_reconstruction_qr(&result, &a, eps);
+        check_orthogonality(&result.q, eps);
+        check_positive_diagonal_qr(&result);
+    }
+
+    #[test]
+    fn test_qr_c64_wide_positive() {
+        let eps = f64::EPSILON * 100.0;
+        let (n, m) = (4, 8);
+        let a: Tensor<c64> = Tensor::randn(&[n, m]);
+
+        let result = qr_positive(&a, &[0], &[1]).unwrap();
+        check_reconstruction_qr(&result, &a, eps);
+        check_orthogonality(&result.q, eps);
+        check_orthogonality_full(&result.q, eps);
+        check_positive_diagonal_qr(&result);
+    }
+
+    #[test]
+    fn test_qr_c64_tall_positive() {
+        let eps = f64::EPSILON * 100.0;
+        let (n, m) = (8, 4);
+        let a: Tensor<c64> = Tensor::randn(&[n, m]);
+
+        let result = qr_positive(&a, &[0], &[1]).unwrap();
+        check_reconstruction_qr(&result, &a, eps);
+        check_orthogonality(&result.q, eps);
+        check_positive_diagonal_qr(&result);
+    }
+
+    #[test]
+    fn test_qr_f64_wide_no_positive() {
+        let eps = f64::EPSILON * 100.0;
+        let (n, m) = (4, 8);
+        let a: Tensor<f64> = Tensor::randn(&[n, m]);
+
+        let result = qr(&a, &[0], &[1]).unwrap();
+        check_reconstruction_qr(&result, &a, eps);
+        check_orthogonality(&result.q, eps);
+        check_orthogonality_full(&result.q, eps);
+    }
+
+    #[test]
+    fn test_qr_f64_tall_no_positive() {
+        let eps = f64::EPSILON * 100.0;
+        let (n, m) = (8, 4);
+        let a: Tensor<f64> = Tensor::randn(&[n, m]);
+
+        let result = qr(&a, &[0], &[1]).unwrap();
+        check_reconstruction_qr(&result, &a, eps);
+        check_orthogonality(&result.q, eps);
+    }
+
+    // ========== QL Tests ==========
+
+    #[test]
+    fn test_ql_f64_wide_positive() {
+        let eps = f64::EPSILON * 100.0;
+        let (n, m) = (4, 8);
+        let a: Tensor<f64> = Tensor::randn(&[n, m]);
+
+        let result = ql_positive(&a, &[0], &[1]).unwrap();
+        check_reconstruction_ql(&result, &a, eps);
+        check_orthogonality(&result.q, eps);
+        check_orthogonality_full(&result.q, eps);
+        check_positive_diagonal_ql(&result);
+    }
+
+    #[test]
+    fn test_ql_f64_tall_positive() {
+        let eps = f64::EPSILON * 100.0;
+        let (n, m) = (8, 4);
+        let a: Tensor<f64> = Tensor::randn(&[n, m]);
+
+        let result = ql_positive(&a, &[0], &[1]).unwrap();
+        check_reconstruction_ql(&result, &a, eps);
+        check_orthogonality(&result.q, eps);
+        check_positive_diagonal_ql(&result);
+    }
+
+    #[test]
+    fn test_ql_c64_wide_positive() {
+        let eps = f64::EPSILON * 100.0;
+        let (n, m) = (4, 8);
+        let a: Tensor<c64> = Tensor::randn(&[n, m]);
+
+        let result = ql_positive(&a, &[0], &[1]).unwrap();
+        check_reconstruction_ql(&result, &a, eps);
+        check_orthogonality(&result.q, eps);
+        check_orthogonality_full(&result.q, eps);
+        check_positive_diagonal_ql(&result);
+    }
+
+    #[test]
+    fn test_ql_c64_tall_positive() {
+        let eps = f64::EPSILON * 100.0;
+        let (n, m) = (8, 4);
+        let a: Tensor<c64> = Tensor::randn(&[n, m]);
+
+        let result = ql_positive(&a, &[0], &[1]).unwrap();
+        check_reconstruction_ql(&result, &a, eps);
+        check_orthogonality(&result.q, eps);
+        check_positive_diagonal_ql(&result);
+    }
+
+    #[test]
+    fn test_ql_f64_wide_no_positive() {
+        let eps = f64::EPSILON * 100.0;
+        let (n, m) = (4, 8);
+        let a: Tensor<f64> = Tensor::randn(&[n, m]);
+
+        let result = ql(&a, &[0], &[1]).unwrap();
+        check_reconstruction_ql(&result, &a, eps);
+        check_orthogonality(&result.q, eps);
+        check_orthogonality_full(&result.q, eps);
+    }
+
+    #[test]
+    fn test_ql_f64_tall_no_positive() {
+        let eps = f64::EPSILON * 100.0;
+        let (n, m) = (8, 4);
+        let a: Tensor<f64> = Tensor::randn(&[n, m]);
+
+        let result = ql(&a, &[0], &[1]).unwrap();
+        check_reconstruction_ql(&result, &a, eps);
+        check_orthogonality(&result.q, eps);
+    }
+
+    // ========== Singular Matrix Tests ==========
+    // Test handling of matrices with rank deficiency
+
+    #[test]
+    fn test_qr_singular_f64() {
+        let eps = f64::EPSILON * 1000.0;
+        let (n, m) = (4, 8);
+
+        // Create a singular matrix by making all rows equal
+        let row: Tensor<f64> = Tensor::randn(&[1, m]);
+        let mut data = Vec::with_capacity(n * m);
+        for _ in 0..n {
+            data.extend_from_slice(row.data());
+        }
+        let a = Tensor::from_vec(data, &[n, m]).unwrap();
+
+        let result = qr_positive(&a, &[0], &[1]).unwrap();
+        check_reconstruction_qr(&result, &a, eps);
+        check_positive_diagonal_qr(&result);
+    }
+
+    #[test]
+    fn test_ql_singular_f64() {
+        let eps = f64::EPSILON * 1000.0;
+        let (n, m) = (4, 8);
+
+        // Create a singular matrix by making all rows equal
+        let row: Tensor<f64> = Tensor::randn(&[1, m]);
+        let mut data = Vec::with_capacity(n * m);
+        for _ in 0..n {
+            data.extend_from_slice(row.data());
+        }
+        let a = Tensor::from_vec(data, &[n, m]).unwrap();
+
+        let result = ql_positive(&a, &[0], &[1]).unwrap();
+        check_reconstruction_ql(&result, &a, eps);
+        check_positive_diagonal_ql(&result);
+    }
+
+    #[test]
+    fn test_qr_singular_c64() {
+        let eps = f64::EPSILON * 1000.0;
+        let (n, m) = (4, 8);
+
+        // Create a singular matrix by making all rows equal
+        let row: Tensor<c64> = Tensor::randn(&[1, m]);
+        let mut data = Vec::with_capacity(n * m);
+        for _ in 0..n {
+            data.extend_from_slice(row.data());
+        }
+        let a = Tensor::from_vec(data, &[n, m]).unwrap();
+
+        let result = qr_positive(&a, &[0], &[1]).unwrap();
+        check_reconstruction_qr(&result, &a, eps);
+        check_positive_diagonal_qr(&result);
+    }
+
+    #[test]
+    fn test_ql_singular_c64() {
+        let eps = f64::EPSILON * 1000.0;
+        let (n, m) = (4, 8);
+
+        // Create a singular matrix by making all rows equal
+        let row: Tensor<c64> = Tensor::randn(&[1, m]);
+        let mut data = Vec::with_capacity(n * m);
+        for _ in 0..n {
+            data.extend_from_slice(row.data());
+        }
+        let a = Tensor::from_vec(data, &[n, m]).unwrap();
+
+        let result = ql_positive(&a, &[0], &[1]).unwrap();
+        check_reconstruction_ql(&result, &a, eps);
+        check_positive_diagonal_ql(&result);
+    }
+}


### PR DESCRIPTION
## Summary

Implements Issue #35 by adding:

- **random_orthog**: Random orthogonal matrix generation using Haar measure via QR decomposition
- **random_unitary**: Random unitary matrix generation using Haar measure via QR decomposition
- **QL decomposition**: Q orthogonal/unitary, L lower triangular from the right side
- **QR/QL with positive diagonal**: Decompositions where diagonal elements are guaranteed to be non-negative real, making them unique

## Test plan

- [x] All new functions have comprehensive tests in `tests/test_linearalgebra.rs`
- [x] Tests mirror NDTensors.jl's `test_linearalgebra.jl` for compatibility
- [x] Tests cover:
  - Orthogonality verification (Q^H * Q = I)
  - Reconstruction verification (Q * R = A, Q * L = A)
  - Positive diagonal verification for positive factorization modes
  - Both f64 and c64 (Complex64) types
  - Wide and tall matrices
  - Singular/rank-deficient matrices
- [x] `cargo test` passes with 305 unit tests + 78 doc tests
- [x] `cargo clippy` passes with no warnings

Closes #35

Generated with [Claude Code](https://claude.com/claude-code)
