### PR TITLE
Implement Combiner storage and CombinerTensor types (Issue #33)

### DIFF
--- a/crates/ndtensors/src/combiner_tensor.rs
+++ b/crates/ndtensors/src/combiner_tensor.rs
@@ -1,0 +1,364 @@
+//! CombinerTensor - Tensor type for index combining operations.
+//!
+//! This module provides `CombinerTensor`, a tensor wrapper for the Combiner
+//! storage type. Combiner tensors represent index combining and uncombining
+//! operations in tensor networks.
+//!
+//! # Overview
+//!
+//! A combiner tensor has:
+//! - Shape: (combined_dim, uncombined_dim_1, uncombined_dim_2, ...)
+//! - By convention, the combined index is at position 0
+//! - No actual data storage (uses Combiner storage)
+//!
+//! # Design
+//!
+//! CombinerTensor mirrors NDTensors.jl's `CombinerTensor` type alias:
+//! ```julia
+//! const CombinerTensor{ElT, N, StoreT, IndsT} =
+//!     Tensor{ElT, N, StoreT, IndsT} where {StoreT <: Combiner}
+//! ```
+//!
+//! # Example
+//!
+//! ```
+//! use ndtensors::combiner_tensor::CombinerTensor;
+//!
+//! // Create a combiner for combining two 2x2 indices into a 4-dimensional index
+//! let tensor = CombinerTensor::new(&[4, 2, 2], vec![1], vec![1]);
+//!
+//! assert_eq!(tensor.shape(), &[4, 2, 2]);
+//! assert_eq!(tensor.ndim(), 3);
+//! assert_eq!(tensor.combined_ind_position(), 0);
+//! assert_eq!(tensor.combined_ind_dim(), 4);
+//! ```
+//!
+//! # Combining and Uncombining
+//!
+//! When contracting with a combiner:
+//! - **Combining**: Multiple indices → single combined index
+//! - **Uncombining**: Single combined index → multiple indices
+//!
+//! Note: Full combining/uncombining contraction operations are planned for future implementation.
+
+use crate::storage::Combiner;
+
+/// A combiner tensor for index combining operations.
+///
+/// CombinerTensor wraps a Combiner storage with shape information.
+/// The shape represents the dimensions of the combined and uncombined indices.
+///
+/// # Convention
+///
+/// - The first index (position 0) is the combined index
+/// - Remaining indices are the uncombined indices
+#[derive(Clone, Debug, PartialEq)]
+pub struct CombinerTensor {
+    storage: Combiner,
+    shape: Vec<usize>,
+}
+
+impl CombinerTensor {
+    /// Create a new combiner tensor.
+    ///
+    /// # Arguments
+    ///
+    /// * `shape` - Shape of the combiner tensor: [combined_dim, uncombined_dim_1, ...]
+    /// * `blockperm` - Block permutation pattern
+    /// * `blockcomb` - Block combination pattern
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ndtensors::combiner_tensor::CombinerTensor;
+    ///
+    /// // Combine two 2x2 indices into one 4-dimensional index
+    /// let combiner = CombinerTensor::new(&[4, 2, 2], vec![1], vec![1]);
+    /// assert_eq!(combiner.shape(), &[4, 2, 2]);
+    /// ```
+    pub fn new(shape: &[usize], blockperm: Vec<usize>, blockcomb: Vec<usize>) -> Self {
+        Self {
+            storage: Combiner::new(blockperm, blockcomb),
+            shape: shape.to_vec(),
+        }
+    }
+
+    /// Create a combiner tensor from existing storage.
+    pub fn from_storage(storage: Combiner, shape: Vec<usize>) -> Self {
+        Self { storage, shape }
+    }
+
+    /// Create a simple combiner for combining indices.
+    ///
+    /// # Arguments
+    ///
+    /// * `combined_dim` - Dimension of the combined index
+    /// * `uncombined_dims` - Dimensions of the uncombined indices
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ndtensors::combiner_tensor::CombinerTensor;
+    ///
+    /// // Combine three dimensions (2, 2, 3) into one (12)
+    /// let combiner = CombinerTensor::simple(12, &[2, 2, 3]);
+    /// assert_eq!(combiner.shape(), &[12, 2, 2, 3]);
+    /// assert_eq!(combiner.combined_ind_dim(), 12);
+    /// ```
+    pub fn simple(combined_dim: usize, uncombined_dims: &[usize]) -> Self {
+        let mut shape = vec![combined_dim];
+        shape.extend_from_slice(uncombined_dims);
+        Self {
+            storage: Combiner::new(vec![1], vec![1]),
+            shape,
+        }
+    }
+
+    /// Get the shape of the combiner tensor.
+    #[inline]
+    pub fn shape(&self) -> &[usize] {
+        &self.shape
+    }
+
+    /// Get the number of dimensions.
+    #[inline]
+    pub fn ndim(&self) -> usize {
+        self.shape.len()
+    }
+
+    /// Get the underlying combiner storage.
+    #[inline]
+    pub fn storage(&self) -> &Combiner {
+        &self.storage
+    }
+
+    /// Get mutable access to the underlying storage.
+    #[inline]
+    pub fn storage_mut(&mut self) -> &mut Combiner {
+        &mut self.storage
+    }
+
+    /// Get the position of the combined index (always 0 by convention).
+    #[inline]
+    pub const fn combined_ind_position(&self) -> usize {
+        0
+    }
+
+    /// Get the dimension of the combined index.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ndtensors::combiner_tensor::CombinerTensor;
+    ///
+    /// let combiner = CombinerTensor::new(&[4, 2, 2], vec![1], vec![1]);
+    /// assert_eq!(combiner.combined_ind_dim(), 4);
+    /// ```
+    pub fn combined_ind_dim(&self) -> usize {
+        self.shape[self.combined_ind_position()]
+    }
+
+    /// Get the dimensions of the uncombined indices.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ndtensors::combiner_tensor::CombinerTensor;
+    ///
+    /// let combiner = CombinerTensor::new(&[4, 2, 2], vec![1], vec![1]);
+    /// assert_eq!(combiner.uncombined_ind_dims(), &[2, 2]);
+    /// ```
+    pub fn uncombined_ind_dims(&self) -> &[usize] {
+        &self.shape[1..]
+    }
+
+    /// Get the number of uncombined indices.
+    pub fn num_uncombined(&self) -> usize {
+        self.ndim() - 1
+    }
+
+    /// Check if the combiner is conjugated.
+    #[inline]
+    pub fn is_conj(&self) -> bool {
+        self.storage.is_conj()
+    }
+
+    /// Create a conjugated version of this combiner tensor.
+    pub fn conj(&self) -> Self {
+        Self {
+            storage: self.storage.conj(),
+            shape: self.shape.clone(),
+        }
+    }
+
+    /// Validate that the combined dimension equals the product of uncombined dimensions.
+    ///
+    /// # Returns
+    ///
+    /// `true` if `combined_dim == product(uncombined_dims)`
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ndtensors::combiner_tensor::CombinerTensor;
+    ///
+    /// let valid = CombinerTensor::new(&[4, 2, 2], vec![1], vec![1]);
+    /// assert!(valid.is_valid_shape());
+    ///
+    /// let invalid = CombinerTensor::new(&[5, 2, 2], vec![1], vec![1]);
+    /// assert!(!invalid.is_valid_shape());
+    /// ```
+    pub fn is_valid_shape(&self) -> bool {
+        let combined = self.combined_ind_dim();
+        let product: usize = self.uncombined_ind_dims().iter().product();
+        combined == product
+    }
+}
+
+impl std::fmt::Display for CombinerTensor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "CombinerTensor(shape={:?}, combined_dim={}, uncombined_dims={:?})",
+            self.shape,
+            self.combined_ind_dim(),
+            self.uncombined_ind_dims()
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_combiner_tensor_new() {
+        let tensor = CombinerTensor::new(&[4, 2, 2], vec![1], vec![1]);
+        assert_eq!(tensor.shape(), &[4, 2, 2]);
+        assert_eq!(tensor.ndim(), 3);
+    }
+
+    #[test]
+    fn test_combiner_tensor_simple() {
+        let tensor = CombinerTensor::simple(12, &[2, 2, 3]);
+        assert_eq!(tensor.shape(), &[12, 2, 2, 3]);
+        assert_eq!(tensor.combined_ind_dim(), 12);
+        assert_eq!(tensor.uncombined_ind_dims(), &[2, 2, 3]);
+    }
+
+    #[test]
+    fn test_combiner_tensor_combined_ind_position() {
+        let tensor = CombinerTensor::new(&[4, 2, 2], vec![1], vec![1]);
+        assert_eq!(tensor.combined_ind_position(), 0);
+    }
+
+    #[test]
+    fn test_combiner_tensor_combined_ind_dim() {
+        let tensor = CombinerTensor::new(&[8, 2, 4], vec![1], vec![1]);
+        assert_eq!(tensor.combined_ind_dim(), 8);
+    }
+
+    #[test]
+    fn test_combiner_tensor_uncombined_ind_dims() {
+        let tensor = CombinerTensor::new(&[6, 2, 3], vec![1], vec![1]);
+        assert_eq!(tensor.uncombined_ind_dims(), &[2, 3]);
+    }
+
+    #[test]
+    fn test_combiner_tensor_num_uncombined() {
+        let tensor = CombinerTensor::new(&[4, 2, 2], vec![1], vec![1]);
+        assert_eq!(tensor.num_uncombined(), 2);
+
+        let tensor2 = CombinerTensor::new(&[8, 2, 2, 2], vec![1], vec![1]);
+        assert_eq!(tensor2.num_uncombined(), 3);
+    }
+
+    #[test]
+    fn test_combiner_tensor_is_conj() {
+        let tensor = CombinerTensor::new(&[4, 2, 2], vec![1], vec![1]);
+        assert!(!tensor.is_conj());
+
+        let conj = tensor.conj();
+        assert!(conj.is_conj());
+    }
+
+    #[test]
+    fn test_combiner_tensor_conj() {
+        let tensor = CombinerTensor::new(&[4, 2, 2], vec![1], vec![1]);
+        let conj = tensor.conj();
+
+        assert!(conj.is_conj());
+        assert_eq!(conj.shape(), tensor.shape());
+
+        let conj_conj = conj.conj();
+        assert!(!conj_conj.is_conj());
+    }
+
+    #[test]
+    fn test_combiner_tensor_is_valid_shape() {
+        // Valid: 4 == 2 * 2
+        let valid = CombinerTensor::new(&[4, 2, 2], vec![1], vec![1]);
+        assert!(valid.is_valid_shape());
+
+        // Valid: 12 == 2 * 2 * 3
+        let valid2 = CombinerTensor::simple(12, &[2, 2, 3]);
+        assert!(valid2.is_valid_shape());
+
+        // Invalid: 5 != 2 * 2
+        let invalid = CombinerTensor::new(&[5, 2, 2], vec![1], vec![1]);
+        assert!(!invalid.is_valid_shape());
+    }
+
+    #[test]
+    fn test_combiner_tensor_from_storage() {
+        let storage = Combiner::new(vec![1, 2], vec![3, 4]);
+        let tensor = CombinerTensor::from_storage(storage.clone(), vec![6, 2, 3]);
+
+        assert_eq!(tensor.shape(), &[6, 2, 3]);
+        assert_eq!(tensor.storage().blockperm(), storage.blockperm());
+    }
+
+    #[test]
+    fn test_combiner_tensor_storage_mut() {
+        let mut tensor = CombinerTensor::new(&[4, 2, 2], vec![1], vec![1]);
+        assert!(!tensor.is_conj());
+
+        tensor.storage_mut().set_conj(true);
+        assert!(tensor.is_conj());
+    }
+
+    #[test]
+    fn test_combiner_tensor_equality() {
+        let t1 = CombinerTensor::new(&[4, 2, 2], vec![1], vec![1]);
+        let t2 = CombinerTensor::new(&[4, 2, 2], vec![1], vec![1]);
+        let t3 = CombinerTensor::new(&[6, 2, 3], vec![1], vec![1]);
+
+        assert_eq!(t1, t2);
+        assert_ne!(t1, t3);
+    }
+
+    #[test]
+    fn test_combiner_tensor_clone() {
+        let t1 = CombinerTensor::new(&[4, 2, 2], vec![1], vec![1]);
+        let t2 = t1.clone();
+        assert_eq!(t1, t2);
+    }
+
+    #[test]
+    fn test_combiner_tensor_display() {
+        let tensor = CombinerTensor::new(&[4, 2, 2], vec![1], vec![1]);
+        let display = format!("{}", tensor);
+
+        assert!(display.contains("CombinerTensor"));
+        assert!(display.contains("shape="));
+        assert!(display.contains("combined_dim="));
+        assert!(display.contains("uncombined_dims="));
+    }
+
+    #[test]
+    fn test_combiner_tensor_debug() {
+        let tensor = CombinerTensor::new(&[4, 2, 2], vec![1], vec![1]);
+        let debug = format!("{:?}", tensor);
+        assert!(debug.contains("CombinerTensor"));
+    }
+}

--- a/crates/ndtensors/src/lib.rs
+++ b/crates/ndtensors/src/lib.rs
@@ -57,6 +57,7 @@
 
 pub mod backend;
 pub mod blocksparse_tensor;
+pub mod combiner_tensor;
 pub mod contract;
 pub mod decomposition;
 pub mod diagblocksparse_tensor;
@@ -70,13 +71,14 @@ pub mod strides;
 pub mod tensor;
 
 pub use blocksparse_tensor::{BlockSparseTensor, CpuBlockSparseTensor};
+pub use combiner_tensor::CombinerTensor;
 pub use contract::{contract, contract_blocksparse, contract_vjp};
 pub use diagblocksparse_tensor::{CpuDiagBlockSparseTensor, DiagBlockSparseTensor};
 pub use empty_number::EmptyNumber;
 pub use error::TensorError;
 pub use scalar::{Scalar, c64};
 pub use storage::{
-    CpuBuffer, CpuDense, CpuDiag, DataBuffer, Dense, Diag, EmptyNumberStorage, EmptyStorage,
-    TensorStorage,
+    Combiner, CpuBuffer, CpuDense, CpuDiag, DataBuffer, Dense, Diag, EmptyNumberStorage,
+    EmptyStorage, TensorStorage,
 };
 pub use tensor::{DenseTensor, Tensor};

--- a/crates/ndtensors/src/storage/combiner.rs
+++ b/crates/ndtensors/src/storage/combiner.rs
@@ -1,0 +1,365 @@
+//! Combiner storage for tensor index combining operations.
+//!
+//! This module provides the `Combiner` storage type which represents
+//! index combining and uncombining operations in tensor networks.
+//! Combiner tensors don't store actual data but define how multiple
+//! indices should be combined into one (or vice versa).
+//!
+//! Mirrors NDTensors.jl's `Combiner <: TensorStorage{Number}` type.
+//!
+//! # Overview
+//!
+//! A combiner tensor has:
+//! - One "combined" index (by convention the first index)
+//! - Multiple "uncombined" indices
+//!
+//! Contracting a tensor with a combiner:
+//! - **Combining**: Contract uncombined indices → combined index replaces them
+//! - **Uncombining**: Contract combined index → uncombined indices replace it
+//!
+//! # Example
+//!
+//! ```
+//! use ndtensors::storage::Combiner;
+//!
+//! // Create a combiner for combining 2 indices
+//! let combiner = Combiner::new(vec![1], vec![1]);
+//!
+//! assert_eq!(combiner.blockperm(), &[1]);
+//! assert_eq!(combiner.blockcomb(), &[1]);
+//! assert!(!combiner.is_conj());
+//! ```
+
+use std::fmt;
+
+/// Combiner storage - represents index combining/uncombining operations.
+///
+/// A combiner defines how to combine multiple tensor indices into a single
+/// index (or the reverse uncombining operation). It stores the permutation
+/// and combination patterns for blocks.
+///
+/// # Type Information
+///
+/// Unlike other storage types, Combiner doesn't store actual data. It stores
+/// metadata about how to perform the combining operation:
+///
+/// * `perm` - Block permutation pattern
+/// * `comb` - Block combination pattern
+/// * `cind` - Combined index positions (default: [1])
+/// * `is_conj` - Whether the combiner is conjugated
+///
+/// # Combining vs Uncombining
+///
+/// When contracting a tensor T with a combiner C:
+/// - If the combined index of C is NOT in T's contracted indices → **combining**
+/// - If the combined index of C IS in T's contracted indices → **uncombining**
+#[derive(Debug, Clone, PartialEq)]
+pub struct Combiner {
+    /// Block permutation pattern.
+    perm: Vec<usize>,
+    /// Block combination pattern.
+    comb: Vec<usize>,
+    /// Combined index positions (by convention, position 0/1 is combined).
+    cind: Vec<usize>,
+    /// Whether the combiner is conjugated.
+    is_conj: bool,
+}
+
+impl Default for Combiner {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+impl Combiner {
+    /// Create a new combiner with given permutation and combination patterns.
+    ///
+    /// # Arguments
+    ///
+    /// * `perm` - Block permutation pattern
+    /// * `comb` - Block combination pattern
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ndtensors::storage::Combiner;
+    ///
+    /// let combiner = Combiner::new(vec![1], vec![1]);
+    /// assert_eq!(combiner.blockperm(), &[1]);
+    /// ```
+    pub fn new(perm: Vec<usize>, comb: Vec<usize>) -> Self {
+        Self {
+            perm,
+            comb,
+            cind: vec![1], // By convention, combined index is at position 1 (0-indexed: 0)
+            is_conj: false,
+        }
+    }
+
+    /// Create a new combiner with full specification.
+    ///
+    /// # Arguments
+    ///
+    /// * `perm` - Block permutation pattern
+    /// * `comb` - Block combination pattern
+    /// * `cind` - Combined index positions
+    /// * `is_conj` - Whether conjugated
+    pub fn new_full(perm: Vec<usize>, comb: Vec<usize>, cind: Vec<usize>, is_conj: bool) -> Self {
+        Self {
+            perm,
+            comb,
+            cind,
+            is_conj,
+        }
+    }
+
+    /// Create an empty combiner.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ndtensors::storage::Combiner;
+    ///
+    /// let combiner = Combiner::empty();
+    /// assert!(combiner.blockperm().is_empty());
+    /// ```
+    pub fn empty() -> Self {
+        Self {
+            perm: Vec::new(),
+            comb: Vec::new(),
+            cind: vec![1],
+            is_conj: false,
+        }
+    }
+
+    /// Get the block permutation pattern.
+    #[inline]
+    pub fn blockperm(&self) -> &[usize] {
+        &self.perm
+    }
+
+    /// Get the block combination pattern.
+    #[inline]
+    pub fn blockcomb(&self) -> &[usize] {
+        &self.comb
+    }
+
+    /// Get the combined index positions.
+    #[inline]
+    pub fn cinds(&self) -> &[usize] {
+        &self.cind
+    }
+
+    /// Check if the combiner is conjugated.
+    #[inline]
+    pub fn is_conj(&self) -> bool {
+        self.is_conj
+    }
+
+    /// Create a conjugated version of this combiner.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ndtensors::storage::Combiner;
+    ///
+    /// let combiner = Combiner::new(vec![1], vec![1]);
+    /// assert!(!combiner.is_conj());
+    ///
+    /// let conj = combiner.conj();
+    /// assert!(conj.is_conj());
+    ///
+    /// // Double conjugation returns to original
+    /// let conj_conj = conj.conj();
+    /// assert!(!conj_conj.is_conj());
+    /// ```
+    pub fn conj(&self) -> Self {
+        Self {
+            perm: self.perm.clone(),
+            comb: self.comb.clone(),
+            cind: self.cind.clone(),
+            is_conj: !self.is_conj,
+        }
+    }
+
+    /// Set the conjugation flag.
+    pub fn set_conj(&mut self, is_conj: bool) {
+        self.is_conj = is_conj;
+    }
+
+    /// Get the position of the combined index (0-indexed).
+    ///
+    /// By convention, the combined index is at position 0.
+    #[inline]
+    pub const fn combined_ind_position(&self) -> usize {
+        0
+    }
+
+    /// Check if the storage is empty.
+    ///
+    /// Combiner storage is always considered "empty" in terms of data
+    /// (it stores no actual tensor elements).
+    #[inline]
+    pub const fn is_empty(&self) -> bool {
+        true
+    }
+
+    /// Get the length (number of stored elements).
+    ///
+    /// Combiner stores no data, so this always returns 0.
+    #[inline]
+    pub const fn len(&self) -> usize {
+        0
+    }
+
+    /// Get the number of non-zero blocks.
+    ///
+    /// Combiner stores no data, so this always returns 0.
+    #[inline]
+    pub const fn nnzblocks(&self) -> usize {
+        0
+    }
+
+    /// Get the number of non-zero elements.
+    ///
+    /// Combiner stores no data, so this always returns 0.
+    #[inline]
+    pub const fn nnz(&self) -> usize {
+        0
+    }
+}
+
+impl fmt::Display for Combiner {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Combiner:")?;
+        writeln!(f, "  Permutation of blocks: {:?}", self.perm)?;
+        write!(f, "  Combination of blocks: {:?}", self.comb)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_combiner_new() {
+        let combiner = Combiner::new(vec![1], vec![1]);
+        assert_eq!(combiner.blockperm(), &[1]);
+        assert_eq!(combiner.blockcomb(), &[1]);
+        assert_eq!(combiner.cinds(), &[1]);
+        assert!(!combiner.is_conj());
+    }
+
+    #[test]
+    fn test_combiner_new_full() {
+        let combiner = Combiner::new_full(vec![1, 2], vec![3, 4], vec![0], true);
+        assert_eq!(combiner.blockperm(), &[1, 2]);
+        assert_eq!(combiner.blockcomb(), &[3, 4]);
+        assert_eq!(combiner.cinds(), &[0]);
+        assert!(combiner.is_conj());
+    }
+
+    #[test]
+    fn test_combiner_empty() {
+        let combiner = Combiner::empty();
+        assert!(combiner.blockperm().is_empty());
+        assert!(combiner.blockcomb().is_empty());
+        assert_eq!(combiner.cinds(), &[1]);
+        assert!(!combiner.is_conj());
+    }
+
+    #[test]
+    fn test_combiner_default() {
+        let combiner: Combiner = Combiner::default();
+        assert!(combiner.blockperm().is_empty());
+    }
+
+    #[test]
+    fn test_combiner_conj() {
+        let combiner = Combiner::new(vec![1], vec![1]);
+        assert!(!combiner.is_conj());
+
+        let conj = combiner.conj();
+        assert!(conj.is_conj());
+        assert_eq!(conj.blockperm(), combiner.blockperm());
+        assert_eq!(conj.blockcomb(), combiner.blockcomb());
+
+        let conj_conj = conj.conj();
+        assert!(!conj_conj.is_conj());
+    }
+
+    #[test]
+    fn test_combiner_set_conj() {
+        let mut combiner = Combiner::new(vec![1], vec![1]);
+        assert!(!combiner.is_conj());
+
+        combiner.set_conj(true);
+        assert!(combiner.is_conj());
+
+        combiner.set_conj(false);
+        assert!(!combiner.is_conj());
+    }
+
+    #[test]
+    fn test_combiner_combined_ind_position() {
+        let combiner = Combiner::new(vec![1], vec![1]);
+        assert_eq!(combiner.combined_ind_position(), 0);
+    }
+
+    #[test]
+    fn test_combiner_is_empty() {
+        let combiner = Combiner::new(vec![1], vec![1]);
+        assert!(combiner.is_empty());
+    }
+
+    #[test]
+    fn test_combiner_len() {
+        let combiner = Combiner::new(vec![1], vec![1]);
+        assert_eq!(combiner.len(), 0);
+    }
+
+    #[test]
+    fn test_combiner_nnzblocks() {
+        let combiner = Combiner::new(vec![1], vec![1]);
+        assert_eq!(combiner.nnzblocks(), 0);
+    }
+
+    #[test]
+    fn test_combiner_nnz() {
+        let combiner = Combiner::new(vec![1], vec![1]);
+        assert_eq!(combiner.nnz(), 0);
+    }
+
+    #[test]
+    fn test_combiner_equality() {
+        let c1 = Combiner::new(vec![1, 2], vec![3, 4]);
+        let c2 = Combiner::new(vec![1, 2], vec![3, 4]);
+        let c3 = Combiner::new(vec![1], vec![3, 4]);
+
+        assert_eq!(c1, c2);
+        assert_ne!(c1, c3);
+    }
+
+    #[test]
+    fn test_combiner_clone() {
+        let c1 = Combiner::new(vec![1, 2], vec![3, 4]);
+        let c2 = c1.clone();
+        assert_eq!(c1, c2);
+    }
+
+    #[test]
+    fn test_combiner_display() {
+        let combiner = Combiner::new(vec![1, 2], vec![3, 4]);
+        let display = format!("{}", combiner);
+        assert!(display.contains("Combiner"));
+        assert!(display.contains("Permutation of blocks"));
+        assert!(display.contains("Combination of blocks"));
+    }
+
+    #[test]
+    fn test_combiner_debug() {
+        let combiner = Combiner::new(vec![1], vec![1]);
+        let debug = format!("{:?}", combiner);
+        assert!(debug.contains("Combiner"));
+    }
+}

--- a/crates/ndtensors/src/storage/mod.rs
+++ b/crates/ndtensors/src/storage/mod.rs
@@ -8,7 +8,8 @@
 //! ├── Diag<ElT, D>            - Diagonal storage
 //! ├── BlockSparse<ElT, D>     - Block sparse storage
 //! ├── DiagBlockSparse<ElT, D> - Diagonal block sparse storage
-//! └── EmptyStorage<ElT>       - Empty (zero-element) storage
+//! ├── EmptyStorage<ElT>       - Empty (zero-element) storage
+//! └── Combiner                - Index combining/uncombining operations
 //! ```
 //!
 //! ## Backend Abstraction
@@ -24,6 +25,7 @@
 
 pub mod blocksparse;
 pub mod buffer;
+mod combiner;
 mod dense;
 mod diag;
 mod empty;
@@ -31,6 +33,7 @@ mod empty;
 use crate::scalar::Scalar;
 
 pub use buffer::{CpuBuffer, DataBuffer};
+pub use combiner::Combiner;
 pub use dense::{CpuDense, Dense};
 pub use diag::{CpuDiag, Diag};
 pub use empty::{EmptyNumberStorage, EmptyStorage};

--- a/crates/ndtensors/tests/test_combiner.rs
+++ b/crates/ndtensors/tests/test_combiner.rs
@@ -1,0 +1,313 @@
+//! Tests for Combiner storage and CombinerTensor.
+//!
+//! These tests cover the basic Combiner functionality, mirroring concepts from
+//! NDTensors.jl's test_combiner.jl. Full combining/uncombining contraction
+//! operations are planned for future implementation.
+//!
+//! # Coverage
+//!
+//! - Combiner storage creation and properties
+//! - CombinerTensor creation and shape handling
+//! - Conjugation operations
+//! - Shape validation
+//!
+//! # Note
+//!
+//! The Julia tests in test_combiner.jl test actual tensor contractions with
+//! combiners (combining and uncombining operations). These are not yet
+//! implemented in Rust. The tests here cover the foundational types.
+
+use ndtensors::combiner_tensor::CombinerTensor;
+use ndtensors::storage::Combiner;
+
+// ============================================================================
+// Combiner Storage Tests
+// ============================================================================
+
+/// Test Combiner creation with permutation and combination patterns.
+#[test]
+fn test_combiner_new() {
+    let combiner = Combiner::new(vec![1], vec![1]);
+
+    assert_eq!(combiner.blockperm(), &[1]);
+    assert_eq!(combiner.blockcomb(), &[1]);
+    assert!(!combiner.is_conj());
+}
+
+/// Test Combiner with full specification.
+#[test]
+fn test_combiner_new_full() {
+    let combiner = Combiner::new_full(vec![1, 2, 3], vec![4, 5], vec![0], true);
+
+    assert_eq!(combiner.blockperm(), &[1, 2, 3]);
+    assert_eq!(combiner.blockcomb(), &[4, 5]);
+    assert_eq!(combiner.cinds(), &[0]);
+    assert!(combiner.is_conj());
+}
+
+/// Test empty Combiner.
+#[test]
+fn test_combiner_empty() {
+    let combiner = Combiner::empty();
+
+    assert!(combiner.blockperm().is_empty());
+    assert!(combiner.blockcomb().is_empty());
+    assert!(!combiner.is_conj());
+}
+
+/// Test Combiner default is empty.
+#[test]
+fn test_combiner_default() {
+    let combiner: Combiner = Default::default();
+
+    assert!(combiner.blockperm().is_empty());
+    assert!(combiner.blockcomb().is_empty());
+}
+
+/// Test Combiner conjugation.
+#[test]
+fn test_combiner_conj() {
+    let combiner = Combiner::new(vec![1, 2], vec![3, 4]);
+    assert!(!combiner.is_conj());
+
+    let conj = combiner.conj();
+    assert!(conj.is_conj());
+    assert_eq!(conj.blockperm(), combiner.blockperm());
+    assert_eq!(conj.blockcomb(), combiner.blockcomb());
+
+    // Double conjugation
+    let conj_conj = conj.conj();
+    assert!(!conj_conj.is_conj());
+}
+
+/// Test Combiner set_conj.
+#[test]
+fn test_combiner_set_conj() {
+    let mut combiner = Combiner::new(vec![1], vec![1]);
+
+    combiner.set_conj(true);
+    assert!(combiner.is_conj());
+
+    combiner.set_conj(false);
+    assert!(!combiner.is_conj());
+}
+
+/// Test Combiner combined_ind_position.
+#[test]
+fn test_combiner_combined_ind_position() {
+    let combiner = Combiner::new(vec![1], vec![1]);
+    assert_eq!(combiner.combined_ind_position(), 0);
+}
+
+/// Test Combiner is_empty always returns true.
+#[test]
+fn test_combiner_is_empty() {
+    let combiner = Combiner::new(vec![1, 2, 3], vec![4, 5, 6]);
+    assert!(combiner.is_empty());
+}
+
+/// Test Combiner len always returns 0.
+#[test]
+fn test_combiner_len() {
+    let combiner = Combiner::new(vec![1, 2], vec![3, 4]);
+    assert_eq!(combiner.len(), 0);
+}
+
+/// Test Combiner nnzblocks always returns 0.
+#[test]
+fn test_combiner_nnzblocks() {
+    let combiner = Combiner::new(vec![1], vec![1]);
+    assert_eq!(combiner.nnzblocks(), 0);
+}
+
+/// Test Combiner nnz always returns 0.
+#[test]
+fn test_combiner_nnz() {
+    let combiner = Combiner::new(vec![1], vec![1]);
+    assert_eq!(combiner.nnz(), 0);
+}
+
+/// Test Combiner equality.
+#[test]
+fn test_combiner_equality() {
+    let c1 = Combiner::new(vec![1, 2], vec![3, 4]);
+    let c2 = Combiner::new(vec![1, 2], vec![3, 4]);
+    let c3 = Combiner::new(vec![1], vec![3, 4]);
+    let c4 = Combiner::new(vec![1, 2], vec![5, 6]);
+
+    assert_eq!(c1, c2);
+    assert_ne!(c1, c3);
+    assert_ne!(c1, c4);
+}
+
+/// Test Combiner clone.
+#[test]
+fn test_combiner_clone() {
+    let c1 = Combiner::new(vec![1, 2], vec![3, 4]);
+    let c2 = c1.clone();
+    assert_eq!(c1, c2);
+}
+
+/// Test Combiner display.
+#[test]
+fn test_combiner_display() {
+    let combiner = Combiner::new(vec![1, 2], vec![3, 4]);
+    let display = format!("{}", combiner);
+
+    assert!(display.contains("Combiner"));
+    assert!(display.contains("Permutation of blocks"));
+    assert!(display.contains("Combination of blocks"));
+}
+
+/// Test Combiner debug.
+#[test]
+fn test_combiner_debug() {
+    let combiner = Combiner::new(vec![1], vec![1]);
+    let debug = format!("{:?}", combiner);
+    assert!(debug.contains("Combiner"));
+}
+
+// ============================================================================
+// CombinerTensor Tests
+// ============================================================================
+
+/// Test CombinerTensor creation.
+/// Mirrors: tensor(Combiner([1], [1]), combiner_tensor_inds)
+#[test]
+fn test_combiner_tensor_new() {
+    // Shape: (combined=4, uncombined1=2, uncombined2=2)
+    let tensor = CombinerTensor::new(&[4, 2, 2], vec![1], vec![1]);
+
+    assert_eq!(tensor.shape(), &[4, 2, 2]);
+    assert_eq!(tensor.ndim(), 3);
+    assert_eq!(tensor.combined_ind_position(), 0);
+    assert_eq!(tensor.combined_ind_dim(), 4);
+    assert_eq!(tensor.uncombined_ind_dims(), &[2, 2]);
+}
+
+/// Test CombinerTensor::simple constructor.
+#[test]
+fn test_combiner_tensor_simple() {
+    // Combine three 2-dimensional indices into one 8-dimensional index
+    let tensor = CombinerTensor::simple(8, &[2, 2, 2]);
+
+    assert_eq!(tensor.shape(), &[8, 2, 2, 2]);
+    assert_eq!(tensor.combined_ind_dim(), 8);
+    assert_eq!(tensor.uncombined_ind_dims(), &[2, 2, 2]);
+    assert!(tensor.is_valid_shape());
+}
+
+/// Test CombinerTensor for combining two indices.
+/// Mirrors Julia: combiner_tensor_inds = (d^2, d, d) where d=2
+#[test]
+fn test_combiner_tensor_two_indices() {
+    // d = 2, so combined = d^2 = 4, uncombined = (d, d) = (2, 2)
+    let tensor = CombinerTensor::new(&[4, 2, 2], vec![1], vec![1]);
+
+    assert_eq!(tensor.combined_ind_dim(), 4);
+    assert_eq!(tensor.uncombined_ind_dims(), &[2, 2]);
+    assert_eq!(tensor.num_uncombined(), 2);
+    assert!(tensor.is_valid_shape());
+}
+
+/// Test CombinerTensor shape validation with valid shape.
+#[test]
+fn test_combiner_tensor_valid_shape() {
+    // 6 = 2 * 3
+    let valid = CombinerTensor::new(&[6, 2, 3], vec![1], vec![1]);
+    assert!(valid.is_valid_shape());
+
+    // 24 = 2 * 3 * 4
+    let valid2 = CombinerTensor::new(&[24, 2, 3, 4], vec![1], vec![1]);
+    assert!(valid2.is_valid_shape());
+}
+
+/// Test CombinerTensor shape validation with invalid shape.
+#[test]
+fn test_combiner_tensor_invalid_shape() {
+    // 5 != 2 * 2
+    let invalid = CombinerTensor::new(&[5, 2, 2], vec![1], vec![1]);
+    assert!(!invalid.is_valid_shape());
+
+    // 10 != 2 * 3
+    let invalid2 = CombinerTensor::new(&[10, 2, 3], vec![1], vec![1]);
+    assert!(!invalid2.is_valid_shape());
+}
+
+/// Test CombinerTensor conjugation.
+#[test]
+fn test_combiner_tensor_conj() {
+    let tensor = CombinerTensor::new(&[4, 2, 2], vec![1], vec![1]);
+    assert!(!tensor.is_conj());
+
+    let conj = tensor.conj();
+    assert!(conj.is_conj());
+    assert_eq!(conj.shape(), tensor.shape());
+
+    let conj_conj = conj.conj();
+    assert!(!conj_conj.is_conj());
+}
+
+/// Test CombinerTensor from_storage.
+#[test]
+fn test_combiner_tensor_from_storage() {
+    let storage = Combiner::new(vec![1, 2], vec![3, 4]);
+    let tensor = CombinerTensor::from_storage(storage.clone(), vec![6, 2, 3]);
+
+    assert_eq!(tensor.shape(), &[6, 2, 3]);
+    assert_eq!(tensor.storage().blockperm(), &[1, 2]);
+}
+
+/// Test CombinerTensor equality.
+#[test]
+fn test_combiner_tensor_equality() {
+    let t1 = CombinerTensor::new(&[4, 2, 2], vec![1], vec![1]);
+    let t2 = CombinerTensor::new(&[4, 2, 2], vec![1], vec![1]);
+    let t3 = CombinerTensor::new(&[6, 2, 3], vec![1], vec![1]);
+
+    assert_eq!(t1, t2);
+    assert_ne!(t1, t3);
+}
+
+/// Test CombinerTensor clone.
+#[test]
+fn test_combiner_tensor_clone() {
+    let t1 = CombinerTensor::new(&[4, 2, 2], vec![1], vec![1]);
+    let t2 = t1.clone();
+    assert_eq!(t1, t2);
+}
+
+/// Test CombinerTensor display.
+#[test]
+fn test_combiner_tensor_display() {
+    let tensor = CombinerTensor::new(&[4, 2, 2], vec![1], vec![1]);
+    let display = format!("{}", tensor);
+
+    assert!(display.contains("CombinerTensor"));
+    assert!(display.contains("shape="));
+    assert!(display.contains("combined_dim=4"));
+    assert!(display.contains("uncombined_dims="));
+}
+
+/// Test CombinerTensor with single uncombined index.
+#[test]
+fn test_combiner_tensor_single_uncombined() {
+    let tensor = CombinerTensor::new(&[3, 3], vec![1], vec![1]);
+
+    assert_eq!(tensor.combined_ind_dim(), 3);
+    assert_eq!(tensor.uncombined_ind_dims(), &[3]);
+    assert_eq!(tensor.num_uncombined(), 1);
+    assert!(tensor.is_valid_shape());
+}
+
+/// Test CombinerTensor with many uncombined indices.
+#[test]
+fn test_combiner_tensor_many_uncombined() {
+    // 24 = 2 * 2 * 2 * 3
+    let tensor = CombinerTensor::new(&[24, 2, 2, 2, 3], vec![1], vec![1]);
+
+    assert_eq!(tensor.combined_ind_dim(), 24);
+    assert_eq!(tensor.uncombined_ind_dims(), &[2, 2, 2, 3]);
+    assert_eq!(tensor.num_uncombined(), 4);
+    assert!(tensor.is_valid_shape());
+}


### PR DESCRIPTION
## Summary

- Implements `Combiner` storage type for index combining operations
- Implements `CombinerTensor` wrapper with shape handling
- Adds comprehensive test suite (27 tests)

## Details

### Combiner Storage

A storage type for index combining/uncombining operations in tensor networks:

- `perm` - Block permutation pattern
- `comb` - Block combination pattern
- `cind` - Combined index positions
- `is_conj` - Conjugation flag

Combiner stores no actual data (metadata only), mirroring NDTensors.jl's design.

### CombinerTensor

A tensor wrapper for Combiner storage with shape information:

- Shape: `[combined_dim, uncombined_dim_1, uncombined_dim_2, ...]`
- Combined index at position 0 by convention
- Shape validation: `combined_dim == product(uncombined_dims)`

### Future Work

Full combining/uncombining contraction operations are planned for future implementation. This PR establishes the foundational types.

## Test plan

- [x] All unit tests pass (`cargo test`)
- [x] Clippy passes with no warnings
- [x] Code formatted with `cargo fmt`
- [x] 16 Combiner storage tests
- [x] 11 CombinerTensor tests

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)