### PR TITLE
Implement forward-mode AD PoC (Issue #55)

### DIFF
--- a/crates/ndtensors/src/autodiff/dual.rs
+++ b/crates/ndtensors/src/autodiff/dual.rs
@@ -1,0 +1,279 @@
+//! DualTensor - Tensor with tangent vector for forward-mode automatic differentiation.
+//!
+//! Forward-mode AD propagates tangent vectors through computations using
+//! Jacobian-vector products (JVP). Given a function f and input x with
+//! tangent v, forward-mode computes:
+//!   - primal: f(x)
+//!   - tangent: J_f(x) * v (Jacobian-vector product)
+//!
+//! This is the dual to backward-mode AD (VJP), which computes v^T * J_f(x).
+//!
+//! # Example
+//!
+//! ```ignore
+//! use ndtensors::autodiff::{DualTensor, dual_contract};
+//! use ndtensors::Tensor;
+//!
+//! // Create dual tensors with tangent vectors
+//! let a = DualTensor::with_tangent(
+//!     Tensor::ones(&[2, 3]),
+//!     Tensor::ones(&[2, 3]),  // tangent = dA
+//! );
+//! let b = DualTensor::new(Tensor::ones(&[3, 4])); // constant (dB = 0)
+//!
+//! // Forward pass propagates tangents using JVP
+//! let c = dual_contract(&a, &[1, -1], &b, &[-1, 2]).unwrap();
+//!
+//! // c.primal() = A @ B
+//! // c.tangent() = dA @ B (product rule, since dB = 0)
+//! ```
+
+use crate::error::TensorError;
+use crate::scalar::Scalar;
+use crate::tensor::DenseTensor;
+
+/// A tensor with an associated tangent vector for forward-mode AD.
+///
+/// `DualTensor` represents a value and its derivative in a given direction.
+/// The tangent can be `None` to represent a zero tangent (constant value),
+/// which allows efficient handling of inputs that don't require differentiation.
+///
+/// # Design
+///
+/// Uses concrete `DenseTensor<T>` rather than type-erased `Box<dyn AnyStorage<T>>`
+/// for consistency with `TrackedTensor` and simplicity. Forward-mode AD doesn't
+/// need graph storage (no tape), so type erasure provides no benefit.
+#[derive(Debug, Clone)]
+pub struct DualTensor<T: Scalar> {
+    /// The primal (function value) tensor.
+    primal: DenseTensor<T>,
+    /// The tangent (derivative) tensor. None represents a zero tangent.
+    tangent: Option<DenseTensor<T>>,
+}
+
+impl<T: Scalar> DualTensor<T> {
+    /// Create a dual tensor with zero tangent (constant).
+    ///
+    /// Use this for inputs that are constants and should not be differentiated.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use ndtensors::autodiff::DualTensor;
+    /// use ndtensors::Tensor;
+    ///
+    /// let constant = DualTensor::new(Tensor::ones(&[2, 3]));
+    /// assert!(!constant.has_tangent());
+    /// ```
+    pub fn new(primal: DenseTensor<T>) -> Self {
+        Self {
+            primal,
+            tangent: None,
+        }
+    }
+
+    /// Create a dual tensor with an explicit tangent vector.
+    ///
+    /// # Arguments
+    ///
+    /// * `primal` - The function value
+    /// * `tangent` - The derivative in some direction
+    ///
+    /// # Returns
+    ///
+    /// Returns an error if the tangent shape doesn't match the primal shape.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use ndtensors::autodiff::DualTensor;
+    /// use ndtensors::Tensor;
+    ///
+    /// let primal = Tensor::from_vec(vec![1.0, 2.0, 3.0], &[3]).unwrap();
+    /// let tangent = Tensor::from_vec(vec![0.1, 0.2, 0.3], &[3]).unwrap();
+    /// let dual = DualTensor::with_tangent(primal, tangent).unwrap();
+    /// assert!(dual.has_tangent());
+    /// ```
+    pub fn with_tangent(
+        primal: DenseTensor<T>,
+        tangent: DenseTensor<T>,
+    ) -> Result<Self, TensorError> {
+        if primal.shape() != tangent.shape() {
+            return Err(TensorError::InvalidOperation(format!(
+                "tangent shape {:?} must match primal shape {:?}",
+                tangent.shape(),
+                primal.shape()
+            )));
+        }
+        Ok(Self {
+            primal,
+            tangent: Some(tangent),
+        })
+    }
+
+    /// Create from primal and optional tangent (internal use).
+    pub(crate) fn from_primal_tangent(
+        primal: DenseTensor<T>,
+        tangent: Option<DenseTensor<T>>,
+    ) -> Self {
+        Self { primal, tangent }
+    }
+
+    /// Get the primal tensor.
+    pub fn primal(&self) -> &DenseTensor<T> {
+        &self.primal
+    }
+
+    /// Get the tangent tensor (None if zero).
+    pub fn tangent(&self) -> Option<&DenseTensor<T>> {
+        self.tangent.as_ref()
+    }
+
+    /// Consume and return primal and tangent.
+    pub fn into_parts(self) -> (DenseTensor<T>, Option<DenseTensor<T>>) {
+        (self.primal, self.tangent)
+    }
+
+    /// Check if this tensor has a non-zero tangent.
+    pub fn has_tangent(&self) -> bool {
+        self.tangent.is_some()
+    }
+
+    /// Get shape (same for primal and tangent).
+    pub fn shape(&self) -> &[usize] {
+        self.primal.shape()
+    }
+
+    /// Get number of dimensions.
+    pub fn ndim(&self) -> usize {
+        self.primal.ndim()
+    }
+
+    /// Get total number of elements.
+    pub fn len(&self) -> usize {
+        self.primal.len()
+    }
+
+    /// Check if tensor is empty.
+    pub fn is_empty(&self) -> bool {
+        self.primal.is_empty()
+    }
+
+    /// Detach tangent, returning a new DualTensor with zero tangent.
+    ///
+    /// This is useful when you want to treat a computed value as a constant
+    /// for subsequent operations.
+    pub fn detach(&self) -> Self {
+        Self {
+            primal: self.primal.clone(),
+            tangent: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Tensor;
+
+    #[test]
+    fn test_dual_tensor_new() {
+        let primal: DenseTensor<f64> = Tensor::from_vec(vec![1.0, 2.0, 3.0], &[3]).unwrap();
+        let dual = DualTensor::new(primal.clone());
+
+        assert_eq!(dual.shape(), &[3]);
+        assert_eq!(dual.ndim(), 1);
+        assert_eq!(dual.len(), 3);
+        assert!(!dual.is_empty());
+        assert!(!dual.has_tangent());
+        assert!(dual.tangent().is_none());
+        assert_eq!(dual.primal().data(), primal.data());
+    }
+
+    #[test]
+    fn test_dual_tensor_with_tangent() {
+        let primal: DenseTensor<f64> = Tensor::from_vec(vec![1.0, 2.0, 3.0], &[3]).unwrap();
+        let tangent: DenseTensor<f64> = Tensor::from_vec(vec![0.1, 0.2, 0.3], &[3]).unwrap();
+        let dual = DualTensor::with_tangent(primal.clone(), tangent.clone()).unwrap();
+
+        assert!(dual.has_tangent());
+        assert_eq!(dual.tangent().unwrap().data(), tangent.data());
+        assert_eq!(dual.primal().data(), primal.data());
+    }
+
+    #[test]
+    fn test_dual_tensor_shape_mismatch() {
+        let primal: DenseTensor<f64> = Tensor::from_vec(vec![1.0, 2.0, 3.0], &[3]).unwrap();
+        let tangent: DenseTensor<f64> = Tensor::from_vec(vec![0.1, 0.2], &[2]).unwrap();
+
+        let result = DualTensor::with_tangent(primal, tangent);
+        assert!(result.is_err());
+        match result {
+            Err(TensorError::InvalidOperation(msg)) => {
+                assert!(msg.contains("tangent shape"));
+                assert!(msg.contains("[2]"));
+                assert!(msg.contains("[3]"));
+            }
+            _ => panic!("Expected InvalidOperation error"),
+        }
+    }
+
+    #[test]
+    fn test_dual_tensor_2d() {
+        let primal: DenseTensor<f64> = Tensor::ones(&[2, 3]);
+        let tangent: DenseTensor<f64> = Tensor::zeros(&[2, 3]);
+        let dual = DualTensor::with_tangent(primal, tangent).unwrap();
+
+        assert_eq!(dual.shape(), &[2, 3]);
+        assert_eq!(dual.ndim(), 2);
+        assert_eq!(dual.len(), 6);
+    }
+
+    #[test]
+    fn test_dual_tensor_detach() {
+        let primal: DenseTensor<f64> = Tensor::ones(&[2, 3]);
+        let tangent: DenseTensor<f64> = Tensor::ones(&[2, 3]);
+        let dual = DualTensor::with_tangent(primal, tangent).unwrap();
+
+        assert!(dual.has_tangent());
+
+        let detached = dual.detach();
+        assert!(!detached.has_tangent());
+        assert_eq!(detached.primal().data(), dual.primal().data());
+    }
+
+    #[test]
+    fn test_dual_tensor_into_parts() {
+        let primal: DenseTensor<f64> = Tensor::from_vec(vec![1.0, 2.0, 3.0], &[3]).unwrap();
+        let tangent: DenseTensor<f64> = Tensor::from_vec(vec![0.1, 0.2, 0.3], &[3]).unwrap();
+        let dual = DualTensor::with_tangent(primal.clone(), tangent.clone()).unwrap();
+
+        let (p, t) = dual.into_parts();
+        assert_eq!(p.data(), primal.data());
+        assert_eq!(t.unwrap().data(), tangent.data());
+    }
+
+    #[test]
+    fn test_dual_tensor_into_parts_no_tangent() {
+        let primal: DenseTensor<f64> = Tensor::from_vec(vec![1.0, 2.0, 3.0], &[3]).unwrap();
+        let dual = DualTensor::new(primal.clone());
+
+        let (p, t) = dual.into_parts();
+        assert_eq!(p.data(), primal.data());
+        assert!(t.is_none());
+    }
+
+    #[test]
+    fn test_dual_tensor_clone() {
+        let primal: DenseTensor<f64> = Tensor::ones(&[2, 3]);
+        let tangent: DenseTensor<f64> = Tensor::ones(&[2, 3]);
+        let dual = DualTensor::with_tangent(primal, tangent).unwrap();
+
+        let cloned = dual.clone();
+        assert_eq!(cloned.primal().data(), dual.primal().data());
+        assert_eq!(
+            cloned.tangent().unwrap().data(),
+            dual.tangent().unwrap().data()
+        );
+    }
+}

--- a/crates/ndtensors/src/autodiff/mod.rs
+++ b/crates/ndtensors/src/autodiff/mod.rs
@@ -60,6 +60,7 @@
 
 mod any_storage;
 mod backward;
+mod dual;
 mod gradients;
 mod graph;
 mod ops;
@@ -68,8 +69,9 @@ mod tensor;
 
 pub use any_storage::AnyStorage;
 pub use backward::backward;
+pub use dual::DualTensor;
 pub use gradients::Gradients;
 pub use graph::{ComputationGraph, GradFn, NodeId, NodeRef, clear_graph_f64, with_graph_f64};
-pub use ops::tracked_contract;
+pub use ops::{dual_contract, tracked_contract};
 pub use saved_tensor::{SavePolicy, SavedTensor};
 pub use tensor::{TrackedTensor, clear_graph};

--- a/crates/ndtensors/src/autodiff/ops/dual_contract.rs
+++ b/crates/ndtensors/src/autodiff/ops/dual_contract.rs
@@ -1,0 +1,252 @@
+//! Dual tensor contraction with JVP (forward-mode AD).
+
+use crate::autodiff::dual::DualTensor;
+use crate::contract::contract;
+use crate::error::TensorError;
+use crate::operations::apply_binary;
+use crate::scalar::Scalar;
+use std::ops::{Add, Mul};
+
+/// Compute tensor contraction with JVP (forward-mode AD).
+///
+/// For contraction `C = contract(A, B)`, the JVP is computed using the
+/// Leibniz product rule:
+///
+///   dC = contract(dA, B) + contract(A, dB)
+///
+/// where dA and dB are the tangent vectors of A and B.
+///
+/// # Arguments
+///
+/// * `a` - First dual tensor
+/// * `labels_a` - Labels for each dimension of `a` (negative = contracted)
+/// * `b` - Second dual tensor
+/// * `labels_b` - Labels for each dimension of `b` (negative = contracted)
+///
+/// # Returns
+///
+/// A dual tensor containing:
+/// - primal: contract(a.primal, b.primal)
+/// - tangent: contract(a.tangent, b.primal) + contract(a.primal, b.tangent)
+///
+/// # Optimization
+///
+/// - If both tangents are None (zero), the output tangent is None
+/// - If only one tangent is None, only one contraction is computed for the tangent
+///
+/// # Example
+///
+/// ```ignore
+/// use ndtensors::autodiff::{DualTensor, dual_contract};
+/// use ndtensors::Tensor;
+///
+/// let a = DualTensor::with_tangent(
+///     Tensor::from_vec(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0], &[2, 3]).unwrap(),
+///     Tensor::ones(&[2, 3]), // dA = ones
+/// ).unwrap();
+/// let b = DualTensor::new(Tensor::ones(&[3, 4])); // dB = 0
+///
+/// // C = A @ B with JVP
+/// let c = dual_contract(&a, &[1, -1], &b, &[-1, 2]).unwrap();
+///
+/// // c.tangent() = dA @ B (since dB = 0)
+/// assert!(c.has_tangent());
+/// ```
+pub fn dual_contract<T: Scalar + Add<Output = T> + Mul<Output = T>>(
+    a: &DualTensor<T>,
+    labels_a: &[i32],
+    b: &DualTensor<T>,
+    labels_b: &[i32],
+) -> Result<DualTensor<T>, TensorError> {
+    // Compute primal: C = contract(A, B)
+    let primal = contract(a.primal(), labels_a, b.primal(), labels_b)?;
+
+    // Compute tangent using Leibniz rule: dC = contract(dA, B) + contract(A, dB)
+    let tangent = match (a.tangent(), b.tangent()) {
+        (None, None) => {
+            // Both inputs are constants, output tangent is zero
+            None
+        }
+        (Some(da), None) => {
+            // dC = contract(dA, B)
+            let dc = contract(da, labels_a, b.primal(), labels_b)?;
+            Some(dc)
+        }
+        (None, Some(db)) => {
+            // dC = contract(A, dB)
+            let dc = contract(a.primal(), labels_a, db, labels_b)?;
+            Some(dc)
+        }
+        (Some(da), Some(db)) => {
+            // dC = contract(dA, B) + contract(A, dB)
+            let dc1 = contract(da, labels_a, b.primal(), labels_b)?;
+            let dc2 = contract(a.primal(), labels_a, db, labels_b)?;
+            let dc = apply_binary(&dc1, &dc2, |x, y| x + y)?;
+            Some(dc)
+        }
+    };
+
+    Ok(DualTensor::from_primal_tangent(primal, tangent))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Tensor;
+    use approx::assert_relative_eq;
+
+    #[test]
+    fn test_dual_contract_no_tangent() {
+        // Both inputs are constants
+        let a: DualTensor<f64> = DualTensor::new(Tensor::ones(&[2, 3]));
+        let b: DualTensor<f64> = DualTensor::new(Tensor::ones(&[3, 4]));
+
+        let c = dual_contract(&a, &[1, -1], &b, &[-1, 2]).unwrap();
+
+        assert_eq!(c.shape(), &[2, 4]);
+        assert!(!c.has_tangent());
+        // Primal: ones(2,3) @ ones(3,4) = 3 * ones(2,4)
+        assert_relative_eq!(*c.primal().get(&[0, 0]).unwrap(), 3.0);
+    }
+
+    #[test]
+    fn test_dual_contract_one_tangent_a() {
+        // Only A has a tangent
+        let a: DualTensor<f64> =
+            DualTensor::with_tangent(Tensor::ones(&[2, 3]), Tensor::ones(&[2, 3])).unwrap();
+        let b: DualTensor<f64> = DualTensor::new(Tensor::ones(&[3, 4]));
+
+        let c = dual_contract(&a, &[1, -1], &b, &[-1, 2]).unwrap();
+
+        assert!(c.has_tangent());
+        assert_eq!(c.tangent().unwrap().shape(), &[2, 4]);
+
+        // dC = dA @ B = ones(2,3) @ ones(3,4) = 3 * ones(2,4)
+        assert_relative_eq!(*c.tangent().unwrap().get(&[0, 0]).unwrap(), 3.0);
+        assert_relative_eq!(*c.tangent().unwrap().get(&[1, 3]).unwrap(), 3.0);
+    }
+
+    #[test]
+    fn test_dual_contract_one_tangent_b() {
+        // Only B has a tangent
+        let a: DualTensor<f64> = DualTensor::new(Tensor::ones(&[2, 3]));
+        let b: DualTensor<f64> =
+            DualTensor::with_tangent(Tensor::ones(&[3, 4]), Tensor::ones(&[3, 4])).unwrap();
+
+        let c = dual_contract(&a, &[1, -1], &b, &[-1, 2]).unwrap();
+
+        assert!(c.has_tangent());
+        // dC = A @ dB = ones(2,3) @ ones(3,4) = 3 * ones(2,4)
+        assert_relative_eq!(*c.tangent().unwrap().get(&[0, 0]).unwrap(), 3.0);
+    }
+
+    #[test]
+    fn test_dual_contract_both_tangents() {
+        // Both inputs have tangents
+        let a: DualTensor<f64> =
+            DualTensor::with_tangent(Tensor::ones(&[2, 3]), Tensor::ones(&[2, 3])).unwrap();
+        let b: DualTensor<f64> =
+            DualTensor::with_tangent(Tensor::ones(&[3, 4]), Tensor::ones(&[3, 4])).unwrap();
+
+        let c = dual_contract(&a, &[1, -1], &b, &[-1, 2]).unwrap();
+
+        assert!(c.has_tangent());
+        // dC = dA @ B + A @ dB = 3 + 3 = 6
+        assert_relative_eq!(*c.tangent().unwrap().get(&[0, 0]).unwrap(), 6.0);
+    }
+
+    #[test]
+    fn test_dual_contract_inner_product() {
+        // Inner product: a . b
+        let a: DualTensor<f64> = DualTensor::with_tangent(
+            Tensor::from_vec(vec![1.0, 2.0, 3.0], &[3]).unwrap(),
+            Tensor::from_vec(vec![1.0, 0.0, 0.0], &[3]).unwrap(), // d/da[0]
+        )
+        .unwrap();
+        let b: DualTensor<f64> =
+            DualTensor::new(Tensor::from_vec(vec![4.0, 5.0, 6.0], &[3]).unwrap());
+
+        let c = dual_contract(&a, &[-1], &b, &[-1]).unwrap();
+
+        // Primal: 1*4 + 2*5 + 3*6 = 32
+        assert_relative_eq!(*c.primal().get_linear(0).unwrap(), 32.0);
+        // Tangent: d/da[0](a.b) = b[0] = 4
+        assert_relative_eq!(*c.tangent().unwrap().get_linear(0).unwrap(), 4.0);
+    }
+
+    #[test]
+    fn test_dual_contract_outer_product() {
+        // Outer product: C[i,j] = a[i] * b[j]
+        let a: DualTensor<f64> = DualTensor::with_tangent(
+            Tensor::from_vec(vec![1.0, 2.0], &[2]).unwrap(),
+            Tensor::from_vec(vec![1.0, 0.0], &[2]).unwrap(), // d/da[0]
+        )
+        .unwrap();
+        let b: DualTensor<f64> =
+            DualTensor::new(Tensor::from_vec(vec![3.0, 4.0, 5.0], &[3]).unwrap());
+
+        let c = dual_contract(&a, &[1], &b, &[2]).unwrap();
+
+        assert_eq!(c.shape(), &[2, 3]);
+        // Primal: C[0,0] = a[0] * b[0] = 1 * 3 = 3
+        assert_relative_eq!(*c.primal().get(&[0, 0]).unwrap(), 3.0);
+        // Tangent: dC[0,0] = da[0] * b[0] = 1 * 3 = 3
+        assert_relative_eq!(*c.tangent().unwrap().get(&[0, 0]).unwrap(), 3.0);
+        // Tangent: dC[1,0] = da[1] * b[0] = 0 * 3 = 0
+        assert_relative_eq!(*c.tangent().unwrap().get(&[1, 0]).unwrap(), 0.0);
+    }
+
+    #[test]
+    fn test_dual_contract_3d_tensor() {
+        // A[i,j,k] * B[k,l] -> C[i,j,l]
+        let a: DualTensor<f64> =
+            DualTensor::with_tangent(Tensor::ones(&[2, 3, 4]), Tensor::ones(&[2, 3, 4])).unwrap();
+        let b: DualTensor<f64> = DualTensor::new(Tensor::ones(&[4, 5]));
+
+        let c = dual_contract(&a, &[1, 2, -1], &b, &[-1, 3]).unwrap();
+
+        assert_eq!(c.shape(), &[2, 3, 5]);
+        // Primal: each element = sum over k of 1*1 = 4
+        assert_relative_eq!(*c.primal().get(&[0, 0, 0]).unwrap(), 4.0);
+        // Tangent: dC = dA @ B, each element = 4
+        assert_relative_eq!(*c.tangent().unwrap().get(&[0, 0, 0]).unwrap(), 4.0);
+    }
+
+    #[test]
+    fn test_dual_contract_vs_finite_diff() {
+        // Verify dual_contract JVP against finite differences
+        let eps = 1e-7;
+
+        let a_data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+        let b_data: Vec<f64> = (1..=12).map(|x| x as f64).collect();
+        let da_data = vec![0.1, 0.2, 0.3, 0.4, 0.5, 0.6];
+
+        let a_primal = Tensor::<f64>::from_vec(a_data.clone(), &[2, 3]).unwrap();
+        let a_tangent = Tensor::<f64>::from_vec(da_data.clone(), &[2, 3]).unwrap();
+        let b = Tensor::<f64>::from_vec(b_data.clone(), &[3, 4]).unwrap();
+
+        // Compute using dual_contract
+        let dual_a: DualTensor<f64> =
+            DualTensor::with_tangent(a_primal.clone(), a_tangent).unwrap();
+        let dual_b: DualTensor<f64> = DualTensor::new(b.clone());
+        let result = dual_contract(&dual_a, &[1, -1], &dual_b, &[-1, 2]).unwrap();
+        let jvp = result.tangent().unwrap();
+
+        // Compute finite difference
+        let a_plus_data: Vec<f64> = a_data
+            .iter()
+            .zip(da_data.iter())
+            .map(|(&x, &d)| x + eps * d)
+            .collect();
+        let a_plus = Tensor::<f64>::from_vec(a_plus_data, &[2, 3]).unwrap();
+
+        let c = contract(&a_primal, &[1, -1], &b, &[-1, 2]).unwrap();
+        let c_plus = contract(&a_plus, &[1, -1], &b, &[-1, 2]).unwrap();
+
+        // Check each element
+        for i in 0..c.len() {
+            let fd = (*c_plus.get_linear(i).unwrap() - *c.get_linear(i).unwrap()) / eps;
+            assert_relative_eq!(*jvp.get_linear(i).unwrap(), fd, epsilon = 1e-5);
+        }
+    }
+}

--- a/crates/ndtensors/src/autodiff/ops/mod.rs
+++ b/crates/ndtensors/src/autodiff/ops/mod.rs
@@ -1,8 +1,11 @@
 //! Tracked tensor operations with automatic differentiation.
 //!
-//! This module provides tracked versions of tensor operations that
-//! record the computation graph for backward pass.
+//! This module provides:
+//! - Tracked operations for backward-mode AD (reverse-mode)
+//! - Dual operations for forward-mode AD (JVP)
 
 mod contract;
+mod dual_contract;
 
 pub use contract::tracked_contract;
+pub use dual_contract::dual_contract;

--- a/crates/ndtensors/src/contract/mod.rs
+++ b/crates/ndtensors/src/contract/mod.rs
@@ -30,7 +30,7 @@ mod gemm;
 mod naive;
 mod properties;
 
-pub use naive::{contract, contract_vjp};
+pub use naive::{contract, contract_jvp, contract_vjp};
 pub use properties::ContractionProperties;
 
 // Re-export GEMM-based contraction for explicit use

--- a/crates/ndtensors/src/lib.rs
+++ b/crates/ndtensors/src/lib.rs
@@ -75,7 +75,7 @@ pub mod autodiff;
 
 pub use blocksparse_tensor::{BlockSparseTensor, CpuBlockSparseTensor};
 pub use combiner_tensor::CombinerTensor;
-pub use contract::{contract, contract_blocksparse, contract_vjp};
+pub use contract::{contract, contract_blocksparse, contract_jvp, contract_vjp};
 pub use diagblocksparse_tensor::{CpuDiagBlockSparseTensor, DiagBlockSparseTensor};
 pub use empty_number::EmptyNumber;
 pub use error::TensorError;


### PR DESCRIPTION
## Summary

- Add forward-mode automatic differentiation using dual numbers
- Complement existing backward-mode AD from #54
- Enable Jacobian-vector products (JVP) for tensor contraction

## New Components

| File | Description |
|------|-------------|
| `autodiff/dual.rs` | `DualTensor<T>` struct with primal and optional tangent |
| `autodiff/ops/dual_contract.rs` | JVP operation using Leibniz rule |
| `contract/naive.rs` | `contract_jvp` primitive |
| `ndtensors-capi/src/lib.rs` | C-API `ndt_tensor_f64_contract_jvp` function |

## JVP Rule

For contraction `C = contract(A, B)`, the JVP follows the product rule:
```
dC = contract(dA, B) + contract(A, dB)
```

Optimization: terms are skipped when tangent is `None` (zero).

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets --features autodiff -- -D warnings`
- [x] `cargo test --features autodiff`
- [x] Unit tests for `DualTensor` construction and accessors
- [x] JVP tests for various tangent combinations
- [x] Numerical verification against finite differences
- [x] C-API tests for `contract_jvp`

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)